### PR TITLE
add NAPI_Initialize and NAPI_Finalize support for nodejs

### DIFF
--- a/core/App/ehsm_napi.cpp
+++ b/core/App/ehsm_napi.cpp
@@ -36,53 +36,37 @@
 using namespace std;
 using namespace EHsmProvider;
 
-static char* StringToChar(string str)
-{
-    char *retChar = NULL;
-    if (str.size() > 0) {
-        int len = str.size();
-        retChar = (char *)malloc(len * sizeof(uint8_t));
-        if(retChar != nullptr){
-            memset(retChar, 0, len);
-            memcpy(retChar, str.c_str(), len);
-        }
-    }
-    return retChar;
-}
-typedef struct {
-    const int CODE_SUCCESS = 200;
-    const int CODE_FAILED = 500;
-    int code = CODE_SUCCESS;
-    std::string msg = "success!";
-    std::string jsonStr;
-	
-	void setCode(int code){code = code;};
-	void setMessage(string message){msg = message;};
-	void addData(string key, uint32_t data) {
-        if(jsonStr.size() > 0){
-            jsonStr += ",";
-        }
-        jsonStr += "\""+key+"\" : " + "\""+std::to_string(data)+"\"";
-    };
-	void addData(string key, string data) {
-        if(jsonStr.size() > 0){
-            jsonStr += ",";
-        }
-        jsonStr += "\""+key+"\" : " + "\""+data+"\"";
-    };
-
-    char* toChar() {
-        std::string retString = "{";
-        retString += "\"code\":" + std::to_string(code);
-        retString += ",\"message\":\"" + msg;
-        retString += "\"";
-        retString += ",\"result\":{"+jsonStr+"}";
-        retString += "}";
-		return StringToChar(retString);
-	};
-} RetJsonObj;
 
 extern "C" {
+
+/*
+create the enclave
+@return
+[string] json string
+    {
+        code: int,
+        message: string,
+        result: {}
+    }
+*/
+char* NAPI_Initialize(){
+    RetJsonObj retJsonObj;
+    ehsm_status_t ret = EH_OK;
+    
+    ret = Initialize();
+    if (ret != EH_OK) {
+        retJsonObj.setCode(retJsonObj.CODE_FAILED);
+        retJsonObj.setMessage("Server exception.");
+    }
+    return retJsonObj.toChar();
+}
+
+/*
+destory the enclave
+*/
+void NAPI_Finalize(){
+    Finalize();
+}
 
 /*
 @return
@@ -108,14 +92,7 @@ char* NAPI_CreateKey(const uint32_t keyspec, const uint32_t origin)
 
     master_key.metadata.keyspec = keyspec;
     master_key.metadata.origin = origin;
-    master_key.keybloblen = 0;
-
-    int rv = Initialize();
-    if (rv != EH_OK) {
-        retJsonObj.setCode(retJsonObj.CODE_FAILED);
-        retJsonObj.setMessage("Server exception.");
-        return retJsonObj.toChar();
-    }
+    master_key.keybloblen = 0;    
 
     ret = CreateKey(&master_key);
     if (ret != EH_OK) {
@@ -150,14 +127,12 @@ char* NAPI_CreateKey(const uint32_t keyspec, const uint32_t origin)
         retJsonObj.addData("cmk_base64", cmk_base64);
         SAFE_FREE(master_key.keyblob);
         SAFE_FREE(resp);
-        Finalize();
         return retJsonObj.toChar();
     }
 
 out:
     SAFE_FREE(master_key.keyblob);
     SAFE_FREE(resp);
-    Finalize();
     return retJsonObj.toChar();
 }
 
@@ -188,13 +163,6 @@ char* NAPI_Encrypt(const char* cmk_base64,
     ehsm_data_t plaint_data;
     ehsm_data_t aad_data;
     ehsm_data_t cipher_data;
-
-    int rv = Initialize();
-    if (rv != EH_OK) {
-        retJsonObj.setCode(retJsonObj.CODE_FAILED);
-        retJsonObj.setMessage("Server exception.");
-        return retJsonObj.toChar();
-    }
 
     decode_str = base64_decode(cmk_base64);
 
@@ -238,14 +206,12 @@ char* NAPI_Encrypt(const char* cmk_base64,
         retJsonObj.addData("ciphertext_base64", cipherText_base64);
         SAFE_FREE(masterkey.keyblob);
         SAFE_FREE(cipher_data.data);
-        Finalize();
         return retJsonObj.toChar();
     }
 
 out:
     SAFE_FREE(masterkey.keyblob);
     SAFE_FREE(cipher_data.data);
-    Finalize();
     return retJsonObj.toChar();
 }
 
@@ -276,13 +242,6 @@ char* NAPI_Decrypt(const char* cmk_base64,
     ehsm_data_t plaint_data;
     ehsm_data_t aad_data;
     ehsm_data_t cipher_data;
-
-    int rv = Initialize();
-    if (rv != EH_OK) {
-        retJsonObj.setCode(retJsonObj.CODE_FAILED);
-        retJsonObj.setMessage("Server exception.");
-        return retJsonObj.toChar();
-    }
 
     decode_cmk = base64_decode(cmk_base64);
 
@@ -328,13 +287,11 @@ char* NAPI_Decrypt(const char* cmk_base64,
         retJsonObj.addData("plaintext_base64", plaintext_base64);
         SAFE_FREE(masterkey.keyblob);
         SAFE_FREE(plaint_data.data);
-        Finalize();
         return retJsonObj.toChar();
     }
 out:
     SAFE_FREE(masterkey.keyblob);
     SAFE_FREE(plaint_data.data);
-    Finalize();
     return retJsonObj.toChar();
 }
 
@@ -366,13 +323,6 @@ char* NAPI_GenerateDataKey(const char* cmk_base64,
 
     string plaintext_base64;
     string ciphertext_base64;
-    
-    int rv = Initialize();
-    if (rv != EH_OK) {
-        retJsonObj.setCode(retJsonObj.CODE_FAILED);
-        retJsonObj.setMessage("Server exception.");
-        return retJsonObj.toChar();
-    }
 
     decode_str = base64_decode(cmk_base64);
 
@@ -393,6 +343,7 @@ char* NAPI_GenerateDataKey(const char* cmk_base64,
         retJsonObj.setMessage("Server exception.");
         goto out;
     }
+	cipher_datakey.datalen = 0;
     ret = GenerateDataKey(&masterkey, &aad_data, &plaint_datakey, &cipher_datakey);
     if (ret != EH_OK) {
         retJsonObj.setCode(retJsonObj.CODE_FAILED);
@@ -432,7 +383,6 @@ char* NAPI_GenerateDataKey(const char* cmk_base64,
             SAFE_FREE(masterkey.keyblob);
             SAFE_FREE(plaint_datakey.data);
             SAFE_FREE(cipher_datakey.data);
-            Finalize();
             return retJsonObj.toChar();
         }
     } 
@@ -441,9 +391,9 @@ out:
     SAFE_FREE(masterkey.keyblob);
     SAFE_FREE(plaint_datakey.data);
     SAFE_FREE(cipher_datakey.data);
-    Finalize();
     return retJsonObj.toChar();
 }
+
 
 //TODO: add the implementation of each ehsm napi
 

--- a/core/App/ehsm_napi.h
+++ b/core/App/ehsm_napi.h
@@ -36,15 +36,84 @@ using namespace std;
 
 extern "C" {
 
+static char* StringToChar(string str)
+{
+    char *retChar = NULL;
+    if (str.size() > 0) {
+        int len = str.size() + 1;
+        retChar = (char *)malloc(len * sizeof(uint8_t));
+        if(retChar != nullptr){
+            memset(retChar, 0, len);
+            memcpy(retChar, str.c_str(), len);
+        }
+    }
+    return retChar;
+}
+
+typedef struct {
+    const int CODE_SUCCESS = 200;
+    const int CODE_FAILED = 500;
+    int code = CODE_SUCCESS;
+    std::string msg = "success!";
+    std::string jsonStr;
+	
+	void setCode(int code){code = code;};
+	void setMessage(string message){msg = message;};
+	void addData(string key, uint32_t data) {
+        if(jsonStr.size() > 0){
+            jsonStr += ",";
+        }
+        jsonStr += "\""+key+"\":" + "\""+std::to_string(data)+"\"";
+    };
+	void addData(string key, string data) {
+        if(jsonStr.size() > 0){
+            jsonStr += ",";
+        }
+        jsonStr += "\""+key+"\":" + "\""+data+"\"";
+    };
+
+  char* toChar() {
+        std::string retString = "{";
+        retString += "\"code\":" + std::to_string(code);
+        retString += ",\"message\":\"" + msg;
+        retString += "\"";
+        retString += ",\"result\":{"+jsonStr+"}";
+        retString += "}";
+        return StringToChar(retString);
+	};
+ 
+  static char* readData(char* jsonChar, std::string key){
+        std::string retVal;
+        std::string jsonString = jsonChar;
+        key = "\"" + key + "\"";
+
+        int startIndex = jsonString.find(key) + key.size() + 1;
+        std::string subStr = jsonString.substr(startIndex);
+
+        if(subStr[0] == '\"'){
+            int endIndex = subStr.find_first_of("\"",1) - 1;
+            retVal = subStr.substr(1,endIndex);
+        }
+        return StringToChar(retVal);
+	};
+} RetJsonObj;
+
 /*
 create the enclave
+@return
+[string] json string
+    {
+        code: int,
+        message: string,
+        result: {}
+    }
 */
 char* NAPI_Initialize();
 
 /*
 destory the enclave
 */
-char* NAPI_Finalize();
+void NAPI_Finalize();
 
 /*
 @return

--- a/ehsm_kms_service/ehsm_kms_server.js
+++ b/ehsm_kms_service/ehsm_kms_server.js
@@ -186,8 +186,25 @@ const ehsm_napi = ffi.Library('./libehsmnapi',{
    */
   'NAPI_GenerateDataKey': ['string',['string', 'int', 'string']],
 
+  /*
+  create the enclave
+  */
+
+  'NAPI_Initialize':['string',[]],
+  
+  /*
+  destory the enclave
+  */
+  'NAPI_Finalize':['string', []],
+
 });
 
+const NAPI_Initialize = ehsm_napi.NAPI_Initialize();
+
+if(JSON.parse(NAPI_Initialize)['code'] != 200) {
+  console.log('service Initialize exception!')
+	process.exit(0);
+}
 
 // base64 encode
 const base64_encode = (str) => new Buffer.from(str).toString('base64')
@@ -206,12 +223,7 @@ const napi_result = (action, res, params) => {
   try {
     // r : NAPI_(*) Return results
     const r = JSON.parse(ehsm_napi[`NAPI_${action}`](...params));
-    if(action == apis.Decrypt && r.code == 200){
-      r.result.plaintext_base64 = base64_decode(r.result.plaintext_base64);
-      res.send(r)
-    } else {
-      res.send(r);
-    }
+    res.send(r);
   } catch (e) {
     res.send(result(400, e))
   }
@@ -257,6 +269,12 @@ app.post('/ehsm', function (req, res) {
     res.send(result(404, 'fail', {}));
   }
 })
+
+process.on('SIGINT', function() {
+  console.log('ehsm kms service exit')
+  ehsm_napi.NAPI_Finalize();
+	process.exit(0);
+});
 
 const  getIPAdress = () => {
   var interfaces = require('os').networkInterfaces();　　

--- a/ehsm_kms_service/test/test_kms_with_rest.py
+++ b/ehsm_kms_service/test/test_kms_with_rest.py
@@ -1,7 +1,7 @@
 import requests
 import json
 import argparse
-
+import base64
 def test_GenerateDataKey(base_url, headers):
     print('====================test_GenerateDataKey start===========================')
     create_req = {
@@ -102,6 +102,8 @@ def test_AES128(base_url, headers):
     print('Decrypt req:\n%s\n' %(decrypt_req))
     decrypt_res = requests.post(url=base_url + "Decrypt", data=json.dumps(decrypt_req), headers=headers)
     print('Decrypt resp:\n%s\n' %(decrypt_res.text))
+    plaintext = str(base64.b64decode(json.loads(decrypt_res.text)['result']['plaintext_base64']), 'utf-8')
+    print('Decrypt plaintext:\n%s\n' %(plaintext))
     print('====================test_AES128 end===========================')
 
 def get_args():


### PR DESCRIPTION
nodejs server will call the initialize to create enclave when it
first start and call the finalize to destory the enclave while the
service is down.

add a new unit test based on the AES128.
- NAPI_CreateKey call
- NAPI_Encrypt call
- NAPI_Decrypt call
test: passed the unittest

Signed-off-by: Liang1XZhao <liang1x.zhao@intel.com>