### PR TITLE
add support for the GenerateDataKeyWithoutPlaintext restful API

### DIFF
--- a/core/App/ehsm_core_test.cpp
+++ b/core/App/ehsm_core_test.cpp
@@ -266,153 +266,86 @@ cleanup:
     return ret;
 }
 
-ehsm_status_t testGenerateDataKey()
+/*
+
+step1. generate an aes-gcm-128 key as the CM(customer master key)
+
+step2. generate a 16 bytes random data key and with plaint text returned
+
+step3. decrypt the cipher text by CMK 
+
+step4. generate a 48 bytes random data key and without plaint text returned
+
+step5. decrypt the cipher text by CMK 
+
+*/
+void test_generate_datakey()
 {
-    ehsm_status_t ret = EH_OK;
-
-    ehsm_keyblob_t cmk;
-    ehsm_data_t aad;
-    ehsm_data_t plaint_datakey;
-    ehsm_data_t cipher_datakey;
-    ehsm_data_t plaint_datakey2;
-    ehsm_data_t cipher_datakey2;
-    ehsm_data_t plaintext1;
-    ehsm_data_t plaintext2;
-
-    printf("============testGenerateDataKey start==========\n");
-    cmk.metadata.origin = EH_INTERNAL_KEY;
-    cmk.metadata.keyspec = EH_AES_GCM_128;
-    cmk.keybloblen = 0;
-
-    /* create an aes-128 key as the cmk */
-    ret = CreateKey(&cmk);
-    if (ret != EH_OK) {
-       printf("Failed(%d) to get the data size of CreateKey with AES key!\n", ret);
-       goto cleanup;
+    printf("============test_generate_datakey start==========\n");
+    char* returnJsonChar = nullptr;
+    char* aad = "challenge";
+	
+	char* cmk_base64 = nullptr;
+    char* ciphertext_base64 = nullptr;
+    char* ciphertext_without_base64 = nullptr;
+    int len_gdk = 16;  
+    int len_gdk_without = 48;
+	
+    returnJsonChar = NAPI_CreateKey(EH_AES_GCM_128, EH_INTERNAL_KEY);
+    if(returnJsonChar == nullptr){
+        printf("Createkey with aes-gcm-128 failed!\n");
+        goto cleanup;
     }
-
-    cmk.keyblob = (uint8_t*)malloc(cmk.keybloblen);
-    if (cmk.keyblob == NULL) {
-       ret = EH_DEVICE_MEMORY;
-       goto cleanup;
-    }
-
-    ret = CreateKey(&cmk);
-    if (ret != EH_OK) {
-       printf("Createkey with aes-gcm-128 failed!\n");
-       goto cleanup;
-    }
+    printf("ckReturn_Json = %s\n", returnJsonChar);
     printf("Create CMK with AES-128 SUCCESSFULLY!\n");
-    dump_data(cmk.keyblob, cmk.keybloblen);
 
     /* generate a 16 bytes random data key and with plaint text returned */
-    aad.data = NULL;
-    aad.datalen = 0;
-
-    plaint_datakey.datalen = 16;
-    plaint_datakey.data = (uint8_t*)malloc(plaint_datakey.datalen);
-    if (plaint_datakey.data == NULL) {
-       ret = EH_DEVICE_MEMORY;
-       goto cleanup;
+    cmk_base64 = RetJsonObj::readData(returnJsonChar, "cmk_base64");
+    returnJsonChar = NAPI_GenerateDataKey(cmk_base64, len_gdk, aad);
+    if(returnJsonChar == nullptr){
+        printf("GenerateDataKey Failed!\n");
+        goto cleanup;
     }
-    dump_data(plaint_datakey.data, plaint_datakey.datalen);
-
-    cipher_datakey.datalen = 0;
-    ret = GenerateDataKey(&cmk, &aad, &plaint_datakey, &cipher_datakey);
-    if (ret != EH_OK) {
-       printf("Failed(%d) to get size of GenerateDataKey!\n", ret);
-       goto cleanup;
-    }
-
-    cipher_datakey.data = (uint8_t*)malloc(cipher_datakey.datalen);
-    if (cipher_datakey.data == NULL) {
-       ret = EH_DEVICE_MEMORY;
-       goto cleanup;
-    }
-
-    ret = GenerateDataKey(&cmk, &aad, &plaint_datakey, &cipher_datakey);
-    if (ret != EH_OK) {
-       printf("Failed(%d) to get size of GenerateDataKey!\n", ret);
-       goto cleanup;
-    }
+    printf("GenerateDataKey_Json = %s\n", returnJsonChar);
+	
+    ciphertext_base64 = RetJsonObj::readData(returnJsonChar, "ciphertext_base64");
     printf("GenerateDataKey SUCCESSFULLY!\n");
-    dump_data(plaint_datakey.data, plaint_datakey.datalen);
-    dump_data(cipher_datakey.data, cipher_datakey.datalen);
-
-    /* try to use the cmk to decrypt the datakey */
-    plaintext1.datalen = 0;
-    ret = Decrypt(&cmk, &cipher_datakey, &aad, &plaintext1);
-    if (ret != EH_OK) {
-       printf("Failed(%d) to get size of Decrypt!\n", ret);
-       goto cleanup;
+	
+    returnJsonChar = NAPI_Decrypt(cmk_base64, ciphertext_base64, aad);
+    if(returnJsonChar == nullptr){
+        printf("Failed to Decrypt the data\n");
+        goto cleanup;
     }
-    plaintext1.data = (uint8_t*)malloc(plaintext1.datalen);
-    if (plaintext1.data == NULL) {
-       ret = EH_DEVICE_MEMORY;
-       goto cleanup;
-    }
-    ret = Decrypt(&cmk, &cipher_datakey, &aad, &plaintext1);
-    if (ret != EH_OK) {
-       printf("Failed(%d) to Decrypt the datakey!\n", ret);
-       goto cleanup;
-    }
-    printf("Decrypt datakey SUCCESSFULLY!\n");
-    dump_data(plaintext1.data, plaintext1.datalen);
+    printf("step1 Decrypt_Json = %s\n", returnJsonChar);
+    printf("Decrypt step1 data SUCCESSFULLY!\n");
 
     /* generate a 48 bytes random data key and without plaint text returned */
-    plaint_datakey2.datalen = 48;
-    plaint_datakey2.data = NULL;
-    cipher_datakey2.datalen = 0;
-    ret = GenerateDataKeyWithoutPlaintext(&cmk, &aad, &plaint_datakey2, &cipher_datakey2);
-    if (ret != EH_OK) {
-       printf("Failed(%d) to get size of GenerateDataKeyWithoutPlaintext!\n", ret);
-       goto cleanup;
+    returnJsonChar = NAPI_GenerateDataKeyWithoutPlaintext(cmk_base64, len_gdk_without, aad);
+    if(returnJsonChar == nullptr){
+        printf("NAPI_GenerateDataKeyWithoutPlaintext Failed!\n");
+        goto cleanup;
     }
-    cipher_datakey2.data = (uint8_t*)malloc(cipher_datakey2.datalen);
-    if (cipher_datakey2.data == NULL) {
-       ret = EH_DEVICE_MEMORY;
-       goto cleanup;
-    }
-
-    ret = GenerateDataKeyWithoutPlaintext(&cmk, &aad, &plaint_datakey2, &cipher_datakey2);
-    if (ret != EH_OK) {
-       printf("Failed(%d) to get size of GenerateDataKey!\n", ret);
-       goto cleanup;
-    }
+    printf("GenerateDataKeyWithoutPlaintext_Json = %s\n", returnJsonChar);
+	
+    ciphertext_without_base64 = RetJsonObj::readData(returnJsonChar, "ciphertext_base64");
     printf("GenerateDataKeyWithoutPlaintext SUCCESSFULLY!\n");
-    dump_data(cipher_datakey2.data, cipher_datakey2.datalen);
 
-    /* try to use the cmk to decrypt the datakey2 */
-    plaintext2.datalen = 0;
-    ret = Decrypt(&cmk, &cipher_datakey2, &aad, &plaintext2);
-    if (ret != EH_OK) {
-       printf("Failed(%d) to get size of Decrypt!\n", ret);
-       goto cleanup;
+    returnJsonChar = NAPI_Decrypt(cmk_base64, ciphertext_without_base64, aad);
+    if(returnJsonChar == nullptr){
+        printf("Failed to Decrypt the data\n");
+        goto cleanup;
     }
-    plaintext2.data = (uint8_t*)malloc(plaintext2.datalen);
-    if (plaintext2.data == NULL) {
-       ret = EH_DEVICE_MEMORY;
-       goto cleanup;
-    }
-    ret = Decrypt(&cmk, &cipher_datakey2, &aad, &plaintext2);
-    if (ret != EH_OK) {
-       printf("Failed(%d) to Decrypt the datakey!\n", ret);
-       goto cleanup;
-    }
-    printf("Decrypt datakey SUCCESSFULLY!\n");
-    dump_data(plaintext2.data, plaintext2.datalen);
-
+    printf("step2 Decrypt_Json = %s\n", returnJsonChar);
+    printf("Decrypt step2 data SUCCESSFULLY!\n");
+    
 cleanup:
-    SAFE_FREE(cmk.keyblob);
-    SAFE_FREE(plaint_datakey.data);
-    SAFE_FREE(cipher_datakey.data);
-    SAFE_FREE(cipher_datakey2.data);
-    SAFE_FREE(plaintext1.data);
-    SAFE_FREE(plaintext2.data);
-
-    printf("============testGenerateDataKey done==========\n");
-    return ret;
+    SAFE_FREE(ciphertext_without_base64);
+    SAFE_FREE(ciphertext_base64);
+    SAFE_FREE(cmk_base64);
+    SAFE_FREE(returnJsonChar);
+    printf("============test_generate_datakey end==========\n");
 }
+
 
 /*
 
@@ -588,7 +521,7 @@ int main(int argc, char* argv[])
 
     test_AES128();
 
-    testGenerateDataKey();
+    test_generate_datakey();
 
     testRSA();
 

--- a/core/App/ehsm_napi.cpp
+++ b/core/App/ehsm_napi.cpp
@@ -125,9 +125,6 @@ char* NAPI_CreateKey(const uint32_t keyspec, const uint32_t origin)
     cmk_base64 = base64_encode(resp, resp_len);
     if(cmk_base64.size() > 0){
         retJsonObj.addData("cmk_base64", cmk_base64);
-        SAFE_FREE(master_key.keyblob);
-        SAFE_FREE(resp);
-        return retJsonObj.toChar();
     }
 
 out:
@@ -204,9 +201,6 @@ char* NAPI_Encrypt(const char* cmk_base64,
     cipherText_base64 = base64_encode(cipher_data.data, cipher_data.datalen);
     if(cipherText_base64.size() > 0){
         retJsonObj.addData("ciphertext_base64", cipherText_base64);
-        SAFE_FREE(masterkey.keyblob);
-        SAFE_FREE(cipher_data.data);
-        return retJsonObj.toChar();
     }
 
 out:
@@ -285,9 +279,6 @@ char* NAPI_Decrypt(const char* cmk_base64,
     plaintext_base64 = base64_encode(plaint_data.data, plaint_data.datalen);
     if(plaintext_base64.size() > 0){
         retJsonObj.addData("plaintext_base64", plaintext_base64);
-        SAFE_FREE(masterkey.keyblob);
-        SAFE_FREE(plaint_data.data);
-        return retJsonObj.toChar();
     }
 out:
     SAFE_FREE(masterkey.keyblob);
@@ -311,8 +302,7 @@ char* NAPI_GenerateDataKey(const char* cmk_base64,
         const uint32_t keylen,
         const char* aad)
 {
-    string decode_str;
-    string decode_cipher;
+    string cmk_str;
     ehsm_status_t ret = EH_OK;
     RetJsonObj retJsonObj;
     ehsm_keyblob_t masterkey;
@@ -323,10 +313,10 @@ char* NAPI_GenerateDataKey(const char* cmk_base64,
 
     string plaintext_base64;
     string ciphertext_base64;
+    
+    cmk_str = base64_decode(cmk_base64);
 
-    decode_str = base64_decode(cmk_base64);
-
-    ret = ehsm_deserialize_cmk(&masterkey, (const uint8_t*)decode_str.data(), decode_str.size());
+    ret = ehsm_deserialize_cmk(&masterkey, (const uint8_t*)cmk_str.data(), cmk_str.size());
     if (ret != EH_OK) {
         retJsonObj.setCode(retJsonObj.CODE_FAILED);
         retJsonObj.setMessage("Server exception.");
@@ -374,18 +364,10 @@ char* NAPI_GenerateDataKey(const char* cmk_base64,
 
     plaintext_base64 = base64_encode(plaint_datakey.data, plaint_datakey.datalen);
     ciphertext_base64 = base64_encode(cipher_datakey.data, cipher_datakey.datalen);
-    if(plaintext_base64.size() > 0 ){
-        retJsonObj.addData("plaintext_base64", plaintext_base64);
-
-        if(ciphertext_base64.size() > 0){
-            retJsonObj.addData("ciphertext_base64", ciphertext_base64);
-
-            SAFE_FREE(masterkey.keyblob);
-            SAFE_FREE(plaint_datakey.data);
-            SAFE_FREE(cipher_datakey.data);
-            return retJsonObj.toChar();
-        }
-    } 
+    if((plaintext_base64.size() > 0) && (ciphertext_base64.size() > 0) ){
+        retJsonObj.addData("plaintext_base64", plaintext_base64); 
+        retJsonObj.addData("ciphertext_base64", ciphertext_base64);
+    }
     
 out:
     SAFE_FREE(masterkey.keyblob);
@@ -394,6 +376,75 @@ out:
     return retJsonObj.toChar();
 }
 
+/*
+@return
+[string] json string
+    {
+        code: int,
+        message: string,
+        result: {
+            ciphertext_base64 : string,
+        }
+    }
+*/
+char* NAPI_GenerateDataKeyWithoutPlaintext(const char* cmk_base64,
+        const uint32_t keylen,
+        const char* aad)
+{
+    RetJsonObj retJsonObj;
+    string cmk_str;
+    ehsm_status_t ret = EH_OK;
+    ehsm_keyblob_t masterkey;
+    ehsm_data_t plaint_datakey;
+    ehsm_data_t aad_data;
+    ehsm_data_t cipher_datakey;
+    string ciphertext_base64;
+    
+    cmk_str = base64_decode(cmk_base64);
+    ret = ehsm_deserialize_cmk(&masterkey, (const uint8_t*)cmk_str.data(), cmk_str.size());
+    if (ret != EH_OK) {
+        retJsonObj.setCode(retJsonObj.CODE_FAILED);
+        retJsonObj.setMessage("Server exception.");
+        goto out;
+    }
+
+    aad_data.datalen = strlen(aad);
+    aad_data.data = (uint8_t*)aad;
+    plaint_datakey.datalen = keylen;
+    plaint_datakey.data = NULL;
+    cipher_datakey.datalen = 0;
+    ret = GenerateDataKeyWithoutPlaintext(&masterkey, &aad_data, &plaint_datakey, &cipher_datakey);
+    if (ret != EH_OK) {
+        retJsonObj.setCode(retJsonObj.CODE_FAILED);
+        retJsonObj.setMessage("Server exception.");
+        goto out;
+    }
+
+    cipher_datakey.data = (uint8_t*)malloc(cipher_datakey.datalen);
+    if (cipher_datakey.data == NULL) {
+        retJsonObj.setCode(retJsonObj.CODE_FAILED);
+        retJsonObj.setMessage("Server exception.");
+        goto out;
+    }
+
+    ret = GenerateDataKeyWithoutPlaintext(&masterkey, &aad_data, &plaint_datakey, &cipher_datakey);
+    if (ret != EH_OK) {
+        retJsonObj.setCode(retJsonObj.CODE_FAILED);
+        retJsonObj.setMessage("Server exception.");
+        goto out;
+    }
+
+    ciphertext_base64 = base64_encode(cipher_datakey.data, cipher_datakey.datalen);
+    if(ciphertext_base64.size() > 0){
+        retJsonObj.addData("ciphertext_base64", ciphertext_base64);
+    }
+
+out:
+    SAFE_FREE(masterkey.keyblob);
+    SAFE_FREE(plaint_datakey.data);
+    SAFE_FREE(cipher_datakey.data);
+    return retJsonObj.toChar();
+}
 
 //TODO: add the implementation of each ehsm napi
 

--- a/core/App/ehsm_napi.h
+++ b/core/App/ehsm_napi.h
@@ -190,9 +190,16 @@ char* NAPI_GenerateDataKey(const char* cmk_base64,
 
 /*
 @return
-[char*] ciphertext -- the cipher datakey
+[string] json string
+    {
+        code: int,
+        message: string,
+        result: {
+            ciphertext_base64 : string,
+        }
+    }
 */
-char* NAPI_GenerateDataKeyWithoutPlaintext(const char* cmk,
+char* NAPI_GenerateDataKeyWithoutPlaintext(const char* cmk_base64,
         const uint32_t keylen,
         const char* aad);
 

--- a/ehsm_kms_service/ehsm_kms_server.js
+++ b/ehsm_kms_service/ehsm_kms_server.js
@@ -171,7 +171,7 @@ const ehsm_napi = ffi.Library('./libehsmnapi',{
 
     params 
      - cmk_base64: string
-     - keylen： string
+     - keylen： number
      - aad: string
      
     return json
@@ -196,6 +196,29 @@ const ehsm_napi = ffi.Library('./libehsmnapi',{
   destory the enclave
   */
   'NAPI_Finalize':['string', []],
+
+  /*
+    NAPI_GenerateDataKeyWithoutPlaintext
+    Description:
+    The same as GenerateDataKey, but doesn’t return plaintext of generated DataKey.
+
+    params 
+     - cmk_base64: string
+     - keylen： number
+     - aad: string
+     
+    return json
+     {
+       code: int,
+       message: string,
+       result: {
+         plaintext_base64 : string,
+         ciphertext_base64 : string,
+       }
+    }
+
+  */
+  'NAPI_GenerateDataKeyWithoutPlaintext': ['string', ['string', 'int', 'string']],
 
 });
 
@@ -265,11 +288,16 @@ app.post('/ehsm', function (req, res) {
    */
     const { cmk_base64,keylen, aad } = PAYLOAD;
     napi_result(ACTION ,res, [cmk_base64, keylen, aad]);
+  } else if(ACTION === apis.GenerateDataKeyWithoutPlaintext) {
+  /**
+   * GenerateDataKeyWithoutPlaintext
+   */
+    const { cmk_base64,keylen, aad } = PAYLOAD;
+    napi_result(ACTION ,res, [cmk_base64, keylen, aad]);
   } else {
     res.send(result(404, 'fail', {}));
   }
 })
-
 process.on('SIGINT', function() {
   console.log('ehsm kms service exit')
   ehsm_napi.NAPI_Finalize();

--- a/ehsm_kms_service/test/test_kms_with_rest.py
+++ b/ehsm_kms_service/test/test_kms_with_rest.py
@@ -2,6 +2,58 @@ import requests
 import json
 import argparse
 import base64
+
+def test_GenerateDataKeyWithoutPlaintext(base_url, headers):
+    print('====================test_GenerateDataKeyWithoutPlaintext start===========================')
+    create_req = {
+        "appid":"t123",
+        "nonce":"t123",
+        "timestamp":"t123",
+        "sign":"t123",
+        "payload":{
+            "keyspec":"EH_AES_GCM_128",
+            "origin":"EH_INTERNAL_KEY"
+        }
+    }
+
+    print('CreateKey req:\n%s\n' %(create_req))
+    create_resp = requests.post(url=base_url + "CreateKey", data=json.dumps(create_req), headers=headers)
+    print('CreateKey resp:\n%s\n' %(create_resp.text))
+
+        # test GenerateDataKey
+    generateDataKeyWithoutPlaintext_req = {
+        "appid":"t123",
+        "nonce":"t123",
+        "timestamp":"t123",
+        "sign":"t123",
+        "payload":{
+            "cmk_base64":json.loads(create_resp.text)['result']['cmk_base64'],
+            "keylen": 16,
+            "aad": "test",
+        }
+    }
+    print('GenerateDataKeyWithoutPlaintext req:\n%s\n' %(generateDataKeyWithoutPlaintext_req))
+    generateDataKeyWithoutPlaintext_resp = requests.post(url=base_url + "GenerateDataKey", data=json.dumps(generateDataKeyWithoutPlaintext_req), headers=headers)
+    print('GenerateDataKeyWithoutPlaintext resp:\n%s\n' %(generateDataKeyWithoutPlaintext_resp.text))
+
+    # test Decrypt(cipher_datakey)
+    decrypt_req = {
+        "appid":"t123",
+        "nonce":"t123",
+        "timestamp":"t123",
+        "sign":"t123",
+        "payload":{
+            "cmk_base64":json.loads(create_resp.text)['result']['cmk_base64'],
+            "ciphertext":json.loads(generateDataKeyWithoutPlaintext_resp.text)['result']['ciphertext_base64'],
+            "aad":"test",
+        }
+    }
+    print('Decrypt req:\n%s\n' %(decrypt_req))
+    decrypt_res = requests.post(url=base_url + "Decrypt", data=json.dumps(decrypt_req), headers=headers)
+    print('Decrypt resp:\n%s\n' %(decrypt_res.text))
+
+    print('====================test_GenerateDataKeyWithoutPlaintext end===========================')
+
 def test_GenerateDataKey(base_url, headers):
     print('====================test_GenerateDataKey start===========================')
     create_req = {
@@ -126,3 +178,5 @@ if __name__ == "__main__":
     test_AES128(base_url, headers)
 
     test_GenerateDataKey(base_url, headers)
+
+    test_GenerateDataKeyWithoutPlaintext(base_url, headers)


### PR DESCRIPTION
this restful API will exposed to public as:
POST <ehsm_srv_address>/ehsm?Action=GenerateDataKeyWithoutPlaintext
add the corresponding test cases.
test: passed the unittest

Signed-off-by: Liang1XZhao <liang1x.zhao@intel.com>