### PR TITLE
add support for API key and AppId enrollment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ ehsm_kms_service/logs/*/
 ehsm_kms_service/*.so
 
 ehsm_kms_service/test/cli/__pycache__
+
+.history/
+.vscode/

--- a/core/App/ehsm_core_test.cpp
+++ b/core/App/ehsm_core_test.cpp
@@ -73,7 +73,7 @@ void test_AES128()
     }
     printf("NAPI_CreateKey Json = %s\n", returnJsonChar);
     printf("Create CMK with AES-128 SUCCESSFULLY!\n");
-    cmk_base64 = retJsonObj.readData_string("cmk_base64");
+    cmk_base64 = retJsonObj.readData_cstr("cmk_base64");
 
     returnJsonChar = NAPI_Encrypt(cmk_base64, plaintext, aad);
     retJsonObj.parse(returnJsonChar);
@@ -85,7 +85,7 @@ void test_AES128()
     printf("NAPI_Encrypt json = %s\n", returnJsonChar);
     printf("Encrypt data SUCCESSFULLY!\n");
 
-    ciphertext_base64 =retJsonObj.readData_string("ciphertext_base64");
+    ciphertext_base64 =retJsonObj.readData_cstr("ciphertext_base64");
 
     returnJsonChar = NAPI_Decrypt(cmk_base64, ciphertext_base64, aad);
     retJsonObj.parse(returnJsonChar);
@@ -95,7 +95,7 @@ void test_AES128()
         goto cleanup; 
     }
     printf("NAPI_Decrypt json = %s\n", returnJsonChar);
-    plaintext_base64 = retJsonObj.readData_string("plaintext_base64");
+    plaintext_base64 = retJsonObj.readData_cstr("plaintext_base64");
     plaintext_decrypt = base64_decode(plaintext_base64);
     printf("Decrypted plaintext = %s\n", plaintext_decrypt.c_str());
     printf("Check decrypt plaintext result with %s: %s\n", plaintext, (plaintext_decrypt == plaintext) ? "true" : "false");
@@ -129,7 +129,7 @@ void test_RSA3072_encrypt_decrypt()
     printf("NAPI_CreateKey Json : %s\n", returnJsonChar);
     printf("Create CMK with RAS SUCCESSFULLY!\n");
 
-    cmk_base64 = retJsonObj.readData_string("cmk_base64");
+    cmk_base64 = retJsonObj.readData_cstr("cmk_base64");
 
     returnJsonChar = NAPI_AsymmetricEncrypt(cmk_base64, plaintext);
     retJsonObj.parse(returnJsonChar);
@@ -140,7 +140,7 @@ void test_RSA3072_encrypt_decrypt()
     printf("NAPI_AsymmetricEncrypt json : %s\n", returnJsonChar);
     printf("NAPI_AsymmetricEncrypt data SUCCESSFULLY!\n");
 
-    ciphertext_base64 = retJsonObj.readData_string("ciphertext_base64");
+    ciphertext_base64 = retJsonObj.readData_cstr("ciphertext_base64");
     returnJsonChar = NAPI_AsymmetricDecrypt(cmk_base64, ciphertext_base64);
     retJsonObj.parse(returnJsonChar);
     if(retJsonObj.getCode() != 200){
@@ -148,7 +148,7 @@ void test_RSA3072_encrypt_decrypt()
         goto cleanup;
     }
     printf("NAPI_AsymmetricDecrypt json : %s\n", returnJsonChar);
-    plaintext_base64 = retJsonObj.readData_string("plaintext_base64");
+    plaintext_base64 = retJsonObj.readData_cstr("plaintext_base64");
     printf("Decrypted plaintext : %s\n",base64_decode(plaintext_base64).c_str());
     printf("NAPI_AsymmetricDecrypt data SUCCESSFULLY!\n");
 
@@ -192,7 +192,7 @@ void test_RSA3072_sign_verify()
     printf("NAPI_CreateKey Json = %s\n", returnJsonChar);
     printf("Create CMK with RAS SUCCESSFULLY!\n");
 
-    cmk_base64 = retJsonObj.readData_string("cmk_base64");
+    cmk_base64 = retJsonObj.readData_cstr("cmk_base64");
 
     digest.datalen = 64;
     digest.data = (uint8_t*)malloc(digest.datalen);
@@ -207,7 +207,7 @@ void test_RSA3072_sign_verify()
         goto cleanup;
     }
     printf("NAPI_Sign Json = %s\n", returnJsonChar);
-    signature_base64 = retJsonObj.readData_string("signature_base64");
+    signature_base64 = retJsonObj.readData_cstr("signature_base64");
     printf("Sign data SUCCESSFULLY!\n");
 
     returnJsonChar = NAPI_Verify(cmk_base64, (char*)digest.data, signature_base64);
@@ -265,7 +265,7 @@ void test_generate_datakey()
     printf("Create CMK with AES-128 SUCCESSFULLY!\n");
 
     /* generate a 16 bytes random data key and with plaint text returned */
-    cmk_base64 = retJsonObj.readData_string("cmk_base64");
+    cmk_base64 = retJsonObj.readData_cstr("cmk_base64");
     returnJsonChar = NAPI_GenerateDataKey(cmk_base64, len_gdk, aad);
     retJsonObj.parse(returnJsonChar);
     if(retJsonObj.getCode() != 200){
@@ -274,7 +274,7 @@ void test_generate_datakey()
     }
     printf("GenerateDataKey_Json = %s\n", returnJsonChar);
 	
-    ciphertext_base64 = retJsonObj.readData_string("ciphertext_base64");
+    ciphertext_base64 = retJsonObj.readData_cstr("ciphertext_base64");
     printf("GenerateDataKey SUCCESSFULLY!\n");
 	
     returnJsonChar = NAPI_Decrypt(cmk_base64, ciphertext_base64, aad);
@@ -295,7 +295,7 @@ void test_generate_datakey()
     }
     printf("GenerateDataKeyWithoutPlaintext_Json = %s\n", returnJsonChar);
 	
-    ciphertext_without_base64 = retJsonObj.readData_string("ciphertext_base64");
+    ciphertext_without_base64 = retJsonObj.readData_cstr("ciphertext_base64");
     printf("GenerateDataKeyWithoutPlaintext SUCCESSFULLY!\n");
 
     returnJsonChar = NAPI_Decrypt(cmk_base64, ciphertext_without_base64, aad);
@@ -353,7 +353,7 @@ void test_export_datakey()
         printf("NAPI_CreateKey failed, error message: %s \n", retJsonObj.getMessage().c_str());
         goto cleanup;
     }
-    cmk_base64 = retJsonObj.readData_string("cmk_base64");
+    cmk_base64 = retJsonObj.readData_cstr("cmk_base64");
     printf("cmk_base64 : %s\n", cmk_base64);
     printf("Create CMK with AES 128 SUCCESSFULLY!\n");
 
@@ -364,7 +364,7 @@ void test_export_datakey()
         printf("NAPI_GenerateDataKeyWithoutPlaintext Failed, error message: %s \n", retJsonObj.getMessage().c_str());
         goto cleanup;
     }
-    olddatakey_base64 = retJsonObj.readData_string("ciphertext_base64");
+    olddatakey_base64 = retJsonObj.readData_cstr("ciphertext_base64");
     printf("olddatakey_base64 : %s\n", olddatakey_base64);
     printf("NAPI_GenerateDataKeyWithoutPlaintext SUCCESSFULLY!\n");
 
@@ -375,7 +375,7 @@ void test_export_datakey()
         printf("Failed to NAPI_Decrypt the data, error message: %s \n", retJsonObj.getMessage().c_str());
         goto cleanup;
     }
-    plaintext_base64 = retJsonObj.readData_string("plaintext_base64");
+    plaintext_base64 = retJsonObj.readData_cstr("plaintext_base64");
     printf("Decrypted plaintext_base64 : %s\n", plaintext_base64);
     printf("NAPI_Decrypt data SUCCESSFULLY!\n");
 
@@ -386,7 +386,7 @@ void test_export_datakey()
         printf("NAPI_CreateKey failed, error message: %s \n", retJsonObj.getMessage().c_str());
         goto cleanup;
     }
-    ukey_base64 = retJsonObj.readData_string("cmk_base64");
+    ukey_base64 = retJsonObj.readData_cstr("cmk_base64");
     printf("ukey_base64 : %s\n", ukey_base64);
     printf("NAPI_CreateKey CMK with RSA SUCCESSFULLY!\n");
 

--- a/core/App/ehsm_napi.h
+++ b/core/App/ehsm_napi.h
@@ -199,6 +199,46 @@ char* NAPI_Verify(const char* cmk_base64,
         const char* digest,
         const char* signature_base64);
 
+/*
+@return
+[string] json string
+    {
+        code: int,
+        message: string,
+        result: {
+            challenge_base64 : string,
+            ga_base64 : string
+        }
+    }
+*/
+char* NAPI_RA_HANDSHAKE_MSG0(const char *p_msg0);
+
+/*
+@return
+[string] json string
+    {
+        code: int,
+        message: string,
+        result: {
+            msg3_base64 : string
+        }
+    }
+*/
+char* NAPI_RA_HANDSHAKE_MSG2(const char *p_msg2);
+
+/*
+@return
+[string] json string
+    {
+        code: int,
+        message: string,
+        result: {
+            appid : string
+            apikey : string
+        }
+    }
+*/
+char* NAPI_RA_GET_API_KEY(const char *p_msg4);
 
 }  // extern "C"
 

--- a/core/App/ehsm_provider.cpp
+++ b/core/App/ehsm_provider.cpp
@@ -46,6 +46,7 @@
 #include "enclave_hsm_u.h"
 #include "ehsm_provider.h"
 
+
 void ocall_print_string(const char *str)
 {
     printf("%s", str);
@@ -808,6 +809,30 @@ ehsm_status_t ExportDataKey(ehsm_keyblob_t *cmk,
         return EH_FUNCTION_FAILED;
     else
         return EH_OK;
+}
+
+ehsm_status_t generate_apikey(ehsm_data_t *apikey)
+{
+    sgx_status_t sgxStatus = SGX_ERROR_UNEXPECTED;
+    sgx_status_t ret = SGX_ERROR_UNEXPECTED;
+
+    // create apikey
+    if (apikey == NULL || apikey->datalen != EH_API_KEY_SIZE) {
+        return EH_ARGUMENTS_BAD;
+    }
+    ret = enclave_generate_apikey(g_enclave_id,
+                            &sgxStatus,
+                            apikey->data,
+                            apikey->datalen);
+    
+    if (ret != SGX_SUCCESS || sgxStatus != SGX_SUCCESS){
+        printf("error: generate apikey faild (%d)(%d).\n", ret, sgxStatus);
+        return EH_FUNCTION_FAILED;
+    }
+    else
+    {
+        return EH_OK;
+    }
 }
 
 }

--- a/core/App/ehsm_provider.h
+++ b/core/App/ehsm_provider.h
@@ -345,5 +345,12 @@ ehsm_status_t Verify(ehsm_keyblob_t *cmk,
              ehsm_data_t *digest,
              ehsm_data_t *signature,
              bool* result);
+
+/*
+*  Description:
+*   Generate a 32-bit random character
+*/
+ehsm_status_t generate_apikey(ehsm_data_t *apikey);
+
 }
 #endif

--- a/core/Enclave/enclave_hsm.cpp
+++ b/core/Enclave/enclave_hsm.cpp
@@ -770,3 +770,26 @@ out:
 
     return ret;
 }
+
+sgx_status_t enclave_generate_apikey(uint8_t *p_apikey, uint32_t apikey_len)
+{
+    sgx_status_t ret = SGX_SUCCESS;
+    if (p_apikey == NULL || apikey_len != EH_API_KEY_SIZE)
+    {
+        return SGX_ERROR_INVALID_PARAMETER;
+    }
+
+    std::string psw_chars = "0123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnpqrstuvwxyz";
+    
+    uint8_t temp[apikey_len];
+    ret = sgx_read_rand(temp, apikey_len);
+    if (ret != SGX_SUCCESS) {
+        return ret;
+    }
+    for (int i = 0; i < apikey_len; i++) {
+        p_apikey[i] = psw_chars[temp[i] % psw_chars.length()];
+    }
+
+    memset_s(temp, apikey_len, 0, apikey_len);
+    return ret;
+}

--- a/core/Enclave/enclave_hsm.edl
+++ b/core/Enclave/enclave_hsm.edl
@@ -105,6 +105,8 @@ enclave {
                                             [out, size=plaintext_len] uint8_t *plaintext, uint32_t plaintext_len,
                                             [out] uint32_t *req_plaintext_len);
 
+        public sgx_status_t enclave_generate_apikey([out, size=apikey_len] uint8_t *p_apikey,
+                                                uint32_t apikey_len);
 
        /* Interfaces used to create local secure channel based on local attestation */
        public uint32_t enclave_la_create_session();

--- a/core/Makefile
+++ b/core/Makefile
@@ -69,7 +69,7 @@ ifeq (true, $(EHSM_DEFAULT_DOMAIN_KEY_FALLBACK))
 endif
 
 App_Cpp_Flags := $(App_C_Flags) -std=c++11
-App_Link_Flags := $(SGX_COMMON_CFLAGS) -L$(SGX_LIBRARY_PATH) -l$(Urts_Library_Name) -L. -lsgx_ukey_exchange -lpthread -ljsoncpp
+App_Link_Flags := $(SGX_COMMON_CFLAGS) -L$(SGX_LIBRARY_PATH) -l$(Urts_Library_Name) -L. -lsgx_ukey_exchange -lpthread -ljsoncpp -luuid
 
 ifneq ($(SGX_MODE), HW)
 	App_Link_Flags += -lsgx_epid_sim -lsgx_quote_ex_sim
@@ -122,7 +122,7 @@ Napi_Include_Paths := \
 
 Napi_C_Flags := $(SGX_COMMON_CFLAGS) -fPIC -Wno-attributes $(App_Include_Paths)
 Napi_Cpp_Flags := $(Napi_C_Flags) -std=c++11
-Napi_Link_Flags := $(SGX_COMMON_CFLAGS) -L$(SGX_LIBRARY_PATH) -l$(Urts_Library_Name) -L. -lsgx_ukey_exchange -lpthread -ljsoncpp -nostartfiles -Wl,--export-dynamic -shared
+Napi_Link_Flags := $(SGX_COMMON_CFLAGS) -L$(SGX_LIBRARY_PATH) -l$(Urts_Library_Name) -L. -lsgx_ukey_exchange -lpthread -ljsoncpp -luuid -nostartfiles -Wl,--export-dynamic -shared
 
 ifneq ($(SGX_MODE), HW)
 	Napi_Link_Flags += -lsgx_epid_sim -lsgx_quote_ex_sim

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,8 @@ RUN apt-get update && apt-get install -y \
     make \
     module-init-tools \
     g++ \
-    libjsoncpp-dev
+    libjsoncpp-dev\
+    uuid-dev
 
 # Install the SDK
 WORKDIR /opt/intel

--- a/ehsm_kms_service/apis.js
+++ b/ehsm_kms_service/apis.js
@@ -14,5 +14,6 @@ const cryptographic_apis = {
 const enroll_apis = {
   RA_GET_API_KEY: 'RA_GET_API_KEY',
   RA_HANDSHAKE_MSG0: 'RA_HANDSHAKE_MSG0',
+  RA_HANDSHAKE_MSG2: 'RA_HANDSHAKE_MSG2',
 }
 module.exports = { cryptographic_apis, enroll_apis }

--- a/ehsm_kms_service/ehsm_napi.js
+++ b/ehsm_kms_service/ehsm_napi.js
@@ -275,7 +275,9 @@ const ehsm_napi = ffi.Library('./libehsmnapi', {
   */
   NAPI_ExportDataKey: ['string', ['string', 'string', 'string', 'string']],
 
-  // NAPI_RA_HANDSHAKE_MSG0: ['string', ['string']],
+  NAPI_RA_HANDSHAKE_MSG0: ['string', ['string']],
+  NAPI_RA_HANDSHAKE_MSG2: ['string', ['string']],
+  NAPI_RA_GET_API_KEY: ['string', ['string']],
 })
 
 module.exports = ehsm_napi

--- a/ehsm_kms_service/enroll_app/Makefile
+++ b/ehsm_kms_service/enroll_app/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2020 Intel Corporation. All rights reserved.
+# Copyright (C) 2020-2021 Intel Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -29,33 +29,49 @@
 #
 #
 
-include buildenv.mk
+include ../../buildenv.mk
 
-SUB_DIR := utils/tkey_exchange utils/ukey_exchange core dkeycache dkeyserver ehsm_kms_service/enroll_app
+App_Name := ehsm-kms_enroll_app
 
-.PHONY: all clean
+OUT = $(TOPDIR)/$(OUTDIR)/$(App_Name)
 
-all:
-	for dir in $(SUB_DIR); do \
-		$(MAKE) -C $$dir; \
-	done
+######## App Settings ########
+App_Cpp_Files := $(wildcard ./*.cpp)
+App_Include_Paths := \
+	-I$(SGX_SDK)/include \
+	-I$(TOPDIR)/include
 
-ifeq ($(Build_Mode), HW_DEBUG)
-	@echo "The project has been built in hardware debug mode."
-else ifeq ($(Build_Mode), HW_RELEAESE)
-	@echo "The project has been built in hardware release mode."
-else ifeq ($(Build_Mode), HW_PRERELEAESE)
-	@echo "The project has been built in hardware pre-release mode."
-else ifeq ($(Build_Mode), SIM_DEBUG)
-	@echo "The project has been built in simulation debug mode."
-else ifeq ($(Build_Mode), SIM_RELEAESE)
-	@echo "The project has been built in simulation release mode."
-else ifeq ($(Build_Mode), SIM_PRERELEAESE)
-	@echo "The project has been built in simulation pre-release mode."
-endif
+App_Cpp_Flags := $(SGX_COMMON_CFLAGS) -fPIC -Wno-attributes $(App_Include_Paths) -std=c++14
+App_Link_Flags := -L$(SGX_LIBRARY_PATH) -l$(Urts_Library_Name) \
+		-L. \
+		-lpthread \
+		-lsgx_dcap_quoteverify \
+		-ldl \
+		-lsample_libcrypto \
+		-ljsoncpp \
+		-lcurl
+
+App_Cpp_Objects := $(App_Cpp_Files:.cpp=.o)
+
+
+######## Build Settings ########
+.PHONY: all target clean
+
+all: target
+	@$(MAKE) target
+	@mkdir -p $(OUT) && mv $(App_Name) $(OUT)
+
+target: $(App_Name)
 
 clean:
-	@rm -rf $(OUTDIR)
-	for dir in $(SUB_DIR); do \
-		$(MAKE) -C $$dir clean; \
-	done
+	@rm -f $(App_Cpp_Objects)
+	@rm -rf $(OUT)
+
+######## AppObjects ########
+%.o: %.cpp
+	@$(CXX) $(App_Cpp_Flags) -c $< -o $@
+	@echo "CXX  <=  $<"
+	
+$(App_Name): $(App_Cpp_Objects)
+	@$(CXX) $^ -o $@ $(App_Link_Flags)
+	@echo :"Link =>  $@"

--- a/ehsm_kms_service/enroll_app/main.cpp
+++ b/ehsm_kms_service/enroll_app/main.cpp
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2021-2022 Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in
+ *      the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the name of Intel Corporation nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY CLEANUP OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+using namespace std;
+
+#include <jsoncpp/json/json.h>
+#include <sys/time.h>
+#include <fstream>
+#include <string>
+
+#include "log_utils.h"
+#include "rest_utils.h"
+
+typedef enum
+{
+    ENL_OK = 0,
+    ENL_CONFIG_INVALID = -1,
+    ENL_POST_EXCEPTION = -2,
+    ENL_NAPI_EXCEPTION = -3,
+    ENL_SERIALIZE_FAILED = -4,
+    ENL_DESERIALIZE_FAILED = -5,
+    ENL_CHALLENGE_NO_COMPARE = -6,
+    ENL_PARSE_MSG1_EXCEPTION = -7,
+    ENL_HANDLE_MSG1_FAILED = -8
+} enroll_status_t;
+
+std::string g_challenge;
+
+enroll_status_t ra_get_msg0(std::string *p_msg0)
+{
+    enroll_status_t ret = ENL_OK;
+    Json::Value msg0_json;
+    struct timeval tv;
+
+    gettimeofday(&tv, NULL);
+    g_challenge = std::to_string(tv.tv_sec) + std::to_string(tv.tv_usec);
+    msg0_json["challenge"] = g_challenge;
+    *p_msg0 = msg0_json.toStyledString();
+    return ret;
+}
+
+enroll_status_t ra_proc_msg1_get_msg2(RetJsonObj retJsonObj_msg1, std::string *p_msg2)
+{
+    enroll_status_t ret = ENL_OK;
+    Json::Value msg2_json;
+    msg2_json["msg2_base64"] = "msg2_base64";
+    *p_msg2 = msg2_json.toStyledString();
+    return ret;
+}
+
+enroll_status_t ra_proc_msg3_get_msg4(RetJsonObj retJsonObj_msg3, std::string *p_msg4)
+{
+    enroll_status_t ret = ENL_OK;
+    Json::Value msg4_json;
+    msg4_json["msg4_base64"] = "msg4_base64";
+    *p_msg4 = msg4_json.toStyledString();
+    return ret;
+}
+
+int main(int argc, char *argv[])
+{
+    log_d("***enroll app start.");
+    enroll_status_t ret = ENL_OK;
+    RetJsonObj retJsonObj;
+
+    std::string msg0_str;
+    std::string msg2_str;
+    std::string msg4_str;
+
+    log_d("=> reading ehsm_kms_url .....");
+    // only one parameter, it is ehsm_kms_url
+    std::string ehsm_kms_url;
+    if (argc == 2)
+    {
+        ehsm_kms_url = argv[1];
+    }
+    if (ehsm_kms_url.empty())
+    {
+        log_e("ehsm_kms_url undefined.Please add ehsm_kms_url after the command.");
+        ret = ENL_CONFIG_INVALID;
+        goto OUT;
+    }
+    log_d("ehsm_kms_url : %s", ehsm_kms_url.c_str());
+
+    log_d("=> First handle send msg0,return msg1.");
+    ret = ra_get_msg0(&msg0_str);
+    log_d("msg0 : \n%s", msg0_str.c_str());
+
+    log_d("post RA_HANDSHAKE_MSG0.....");
+    post_KMS(ehsm_kms_url + "?Action=RA_HANDSHAKE_MSG0", msg0_str, &retJsonObj);
+    if (!retJsonObj.isSuccess())
+    {
+        log_e("NAPI Exception: %s", retJsonObj.getMessage().c_str());
+        ret = ENL_NAPI_EXCEPTION;
+        goto OUT;
+    }
+    log_d("post success msg1 : \n%s", retJsonObj.toString().c_str());
+    log_d("First handle success.");
+
+    log_d("=> Second handle send msg2,return msg3.");
+    ret = ra_proc_msg1_get_msg2(retJsonObj, &msg2_str);
+    if (ret != ENL_OK || msg2_str.empty())
+    {
+        log_e("ra_proc_msg1_get_msg2 failed. error code [%d]\n", ret);
+        goto OUT;
+    }
+    log_d("msg2 : \n%s", msg2_str.c_str());
+
+    post_KMS(ehsm_kms_url + "?Action=RA_HANDSHAKE_MSG2", msg2_str, &retJsonObj);
+    if (!retJsonObj.isSuccess())
+    {
+        log_e("NAPI Exception: %s", retJsonObj.getMessage().c_str());
+        ret = ENL_NAPI_EXCEPTION;
+        goto OUT;
+    }
+    log_d("post success msg3 : \n%s", retJsonObj.toString().c_str());
+    log_d("Second handle success.");
+
+    log_d("=> Third handle send msg4,return msg7.");
+    ret = ra_proc_msg3_get_msg4(retJsonObj, &msg4_str);
+    if (ret != ENL_OK || msg4_str.empty())
+    {
+        log_e("ra_proc_msg1_get_msg2 failed. error code [%d]\n", ret);
+        ret = ENL_NAPI_EXCEPTION;
+        goto OUT;
+    }
+    log_d("msg4 : \n%s", msg4_str.c_str());
+
+    post_KMS(ehsm_kms_url + "?Action=RA_GET_API_KEY", msg4_str, &retJsonObj);
+    if (!retJsonObj.isSuccess())
+    {
+        log_e("NAPI Exception: %s", retJsonObj.getMessage().c_str());
+        ret = ENL_NAPI_EXCEPTION;
+        goto OUT;
+    }
+    log_d("post success msg7 : \n%s", retJsonObj.toString().c_str());
+
+    printf("\n**************** Enroll APP **********************");
+    printf("\n\nappid: %s", retJsonObj.readData_cstr("appid"));
+    printf("\n\napikey: %s", retJsonObj.readData_cstr("apikey"));
+    printf("\n\n**************************************************\n\n");
+
+    log_d("Third handle success.");
+OUT:
+    log_d("***enroll app end.");
+    return ret;
+}

--- a/ehsm_kms_service/enroll_app/rest_utils.cpp
+++ b/ehsm_kms_service/enroll_app/rest_utils.cpp
@@ -31,6 +31,16 @@
 #include <cstdlib>
 #include "rest_utils.h"
 
+size_t post_callback(void *ptr, size_t size, size_t nmemb, void *stream)
+{
+    std::string *str = (std::string*)stream;
+	(*str).append((char*)ptr, size*nmemb);
+	return size * nmemb;
+}
+
+/*
+* base post
+*/
 std::string post(std::string url, std::string content){
     struct curl_slist* header_list = nullptr;
     // use curl post.
@@ -46,7 +56,7 @@ std::string post(std::string url, std::string content){
     curl_easy_setopt(curl, CURLOPT_URL, url.data());
     header_list = curl_slist_append(header_list, "Content-Type:application/json; charset=UTF-8");
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header_list);
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, req_callback);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, post_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&response);
     curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
     curl_easy_setopt(curl, CURLOPT_POST, 1);
@@ -63,11 +73,11 @@ out:
     return response;
 }
 
-size_t req_callback(void *ptr, size_t size, size_t nmemb, void *stream)
-{
-    std::string *str = (std::string*)stream;
-	(*str).append((char*)ptr, size*nmemb);
-	return size * nmemb;
+/*
+* KMS server post
+*/
+void post_KMS(std::string url, std::string content, RetJsonObj *retJsonObj){
+    std::string json_str = post(url, content);
+    retJsonObj->parse(json_str);
 }
-
 

--- a/ehsm_kms_service/enroll_app/rest_utils.h
+++ b/ehsm_kms_service/enroll_app/rest_utils.h
@@ -30,16 +30,24 @@
  */
 
 
-#ifndef _REST_UTILS_H
-#define _REST_UTILS_H
+#ifndef _ENROLL_APP_REST_UTILS_H
+#define _ENROLL_APP_REST_UTILS_H
 
 #include <stdio.h>
 #include <curl/curl.h>
 #include <iostream>
 
+#include "json_utils.h"
 
+
+/*
+* base post
+*/
 std::string post(std::string url, std::string content);
-size_t req_callback(void *ptr, size_t size, size_t nmem, void *stream);
+/*
+* KMS server post
+*/
+void post_KMS(std::string url, std::string content, RetJsonObj *retJsonObj);
 
 #endif
 

--- a/ehsm_kms_service/router.js
+++ b/ehsm_kms_service/router.js
@@ -56,7 +56,7 @@ const router = async (p) => {
   const action = req.query.Action
   switch (action) {
     case enroll_apis.RA_GET_API_KEY:
-      create_user_info(DB, res)
+      create_user_info(action, DB, res, req)
       break
     case cryptographic_apis.CreateKey:
       try {
@@ -150,6 +150,20 @@ const router = async (p) => {
           aad,
           olddatakey_base,
         ])
+        napi_res && res.send(napi_res)
+      } catch (error) {}
+      break
+    case enroll_apis.RA_HANDSHAKE_MSG0:
+      try {
+        const json_str_params = JSON.stringify({ ...req.body })
+        napi_res = napi_result(action, res, [json_str_params])
+        napi_res && res.send(napi_res)
+      } catch (error) {}
+      break
+    case enroll_apis.RA_HANDSHAKE_MSG2:
+      try {
+        const json_str_params = JSON.stringify({ ...req.body })
+        napi_res = napi_result(action, res, [json_str_params])
         napi_res && res.send(napi_res)
       } catch (error) {}
       break

--- a/ehsm_kms_service/test/test_kms_with_rest.py
+++ b/ehsm_kms_service/test/test_kms_with_rest.py
@@ -10,7 +10,7 @@ from collections import OrderedDict
 import urllib.parse
 
 appid=''
-appkey = ''
+apikey = ''
 
 def test_creat_app_info(base_url, headers):
     print('====================test_creat_app_info start===========================')
@@ -18,9 +18,9 @@ def test_creat_app_info(base_url, headers):
     if(check_result(creat_app_info_resp, 'RA_GET_API_KEY', 'test_creat_app_info') == False):
         return
     global appid 
-    global appkey 
+    global apikey 
     appid = json.loads(creat_app_info_resp.text)['result']['appid']
-    appkey = json.loads(creat_app_info_resp.text)['result']['appkey']
+    apikey = json.loads(creat_app_info_resp.text)['result']['apikey']
     print('CreateKey resp(EH_AES_GCM_128):\n%s\n' %(creat_app_info_resp.text))
     print('====================test_creat_app_info end===========================')
 
@@ -31,7 +31,7 @@ def test_params(payload):
     params["payload"] = urllib.parse.unquote(urllib.parse.urlencode(payload))
     params["timestamp"] = str(int(time.time() * 1000))
     sign_string = urllib.parse.unquote(urllib.parse.urlencode(params))
-    sign = str(base64.b64encode(hmac.new(appkey.encode('utf-8'), sign_string.encode('utf-8'), digestmod=sha256).digest()),'utf-8').upper()
+    sign = str(base64.b64encode(hmac.new(apikey.encode('utf-8'), sign_string.encode('utf-8'), digestmod=sha256).digest()),'utf-8').upper()
     params["payload"] = payload
     params["sign"] = sign
     return params

--- a/include/datatypes.h
+++ b/include/datatypes.h
@@ -44,6 +44,8 @@
 #define MAC_KEY_SIZE       16
 #define PADDING_SIZE       16
 
+#define EH_API_KEY_SIZE     32
+
 #define TAG_SIZE        16
 #define IV_SIZE            12
 

--- a/include/json_utils.h
+++ b/include/json_utils.h
@@ -31,47 +31,59 @@
 #ifndef _JSON_UTILS_H
 #define _JSON_UTILS_H
 
+#include <cstring>
 #include <jsoncpp/json/json.h>
 
-class RetJsonObj{
+class RetJsonObj
+{
 public:
     const int CODE_SUCCESS = 200;
     const int CODE_BAD_REQUEST = 400;
     const int CODE_FAILED = 500;
+
 private:
     Json::Value m_json;
     Json::Value m_result_json;
 
 public:
-    RetJsonObj(){
+    RetJsonObj()
+    {
         m_json["code"] = CODE_SUCCESS;
         m_json["message"] = "success!";
     }
     virtual ~RetJsonObj(){};
-     
-    void setCode(int code){
+
+    void setCode(int code)
+    {
         m_json["code"] = code;
     }
-    void setMessage(std::string message){
+    void setMessage(std::string message)
+    {
         m_json["message"] = message;
     }
-    void addData(std::string key, bool data){
+
+    void addData_string(std::string key, std::string data)
+    {
         m_result_json[key] = data;
     }
-    void addData(std::string key, int data){
+    void addData_bool(std::string key, bool data)
+    {
         m_result_json[key] = data;
     }
-    void addData(std::string key, std::string data){
+    void addData_int(std::string key, int data)
+    {
         m_result_json[key] = data;
     }
 
-    char* StringToChar(std::string str)
+    char *StringToChar(std::string str)
     {
         char *retChar = NULL;
-        if (str.size() > 0) {
+        if (str.size() > 0)
+        {
             int len = str.size() + 1;
             retChar = (char *)malloc(len * sizeof(uint8_t));
-            if(retChar != nullptr){
+            if (retChar != nullptr)
+            {
                 memset(retChar, 0, len);
                 memcpy(retChar, str.c_str(), len);
             }
@@ -79,39 +91,69 @@ public:
         return retChar;
     }
 
-    char* toChar() {
+    std::string toString()
+    {
         m_json["result"] = m_result_json;
-        return StringToChar(m_json.toStyledString());
+        return m_json.toStyledString();
     }
 
-    void parse(std::string jsonStr){
+    char *toChar()
+    {
+        return StringToChar(toString());
+    }
+
+    void parse(std::string jsonStr)
+    {
         Json::Reader *pJsonParser = new Json::Reader();
         bool res = pJsonParser->parse(jsonStr, m_json);
         m_result_json = m_json["result"];
-        if (!res) {
+        if (!res || m_json["code"].asInt() == 0)
+        {
             printf("Error: can't parse json string :  %s \n", jsonStr.c_str());
+            setCode(CODE_BAD_REQUEST);
+            setMessage("The returned JSON is malformed.");
         }
     }
 
-    void parse(char* jsonChar){
+    void parse(char *jsonChar)
+    {
         std::string jsonStr = jsonChar;
         parse(jsonStr);
     }
 
-    int getCode(){
+    int getCode()
+    {
         return m_json["code"].asInt();
     }
 
-    std::string getMessage(){
+    bool isSuccess()
+    {
+        return getCode() == CODE_SUCCESS;
+    }
+
+    std::string getMessage()
+    {
         return m_json["message"].asString();
     }
- 
-    char* readData_string(std::string key){
+
+    char *readData_cstr(std::string key)
+    {
         return StringToChar(m_result_json[key].asString());
     }
- 
-    bool readData_bool(std::string key){
+
+    std::string readData_string(std::string key)
+    {
+        return StringToChar(m_result_json[key].asString());
+    }
+
+    bool readData_bool(std::string key)
+    {
         return m_result_json[key].asBool();
+    }
+
+    uint32_t readData_int(std::string key)
+    {
+        return m_result_json[key].asInt();
     }
 };
 

--- a/include/log_utils.h
+++ b/include/log_utils.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2011-2020 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef _LOG_UTILS_H
+#define _LOG_UTILS_H
+
+#include <stdio.h>
+#include <stdarg.h>
+
+#define IS_DEBUG false
+
+
+
+/*
+    print info
+*/
+#define log_i(format, args...)                                           \
+    {                                                                      \
+        printf("INFO [%d]\t[%s -> %s]: ", __LINE__, __FILE__, __FUNCTION__); \
+        printf(format, ##args);                                            \
+        printf("\n");                                                      \
+    }
+/*
+    print debug
+*/
+#define log_d(format, args...)                                                \
+    {                                                                           \
+        if (IS_DEBUG)                                                           \
+        {                                                                       \
+            printf("DEBUG [%d]\t[%s -> %s]: ", __LINE__, __FILE__, __FUNCTION__); \
+            printf(format, ##args);                                             \
+            printf("\n");                                                       \
+        }                                                                       \
+    }
+/*
+    print warn
+*/
+#define log_w(format, args...)                                           \
+    {                                                                      \
+        printf("WARN [%d]\t[%s -> %s]: ", __LINE__, __FILE__, __FUNCTION__); \
+        printf(format, ##args);                                            \
+        printf("\n");                                                      \
+    }
+/*
+    print error
+*/
+#define log_e(format, args...)                                            \
+    {                                                                       \
+        printf("ERROR [%d]\t[%s -> %s]: ", __LINE__, __FILE__, __FUNCTION__); \
+        printf(format, ##args);                                             \
+        printf("\n");                                                       \
+    }
+
+#endif


### PR DESCRIPTION
The new application (ehsm-kms_enroll_app) is responsible for obtaining
a valid access secret (API key and AppId) from ehsm-core enclave.

And the access secret is displayed only during the enrollment process, you
cannot query the access secret in subsequent crypto operations. Therefore,
you must back up your access secret, if they're leaked or lost, you must create
another one.

Currently, the access secrets are transferred w/o secure channel protection, and
later we will establish a secure channel via the sgx remote attestation to assure its
security.

Signed-off-by: wanghouqi <wanghouqi@vip.qq.com>