### PR TITLE
Modify base64 encoding feature about some input paraments

### DIFF
--- a/core/App/ehsm_napi.h
+++ b/core/App/ehsm_napi.h
@@ -77,8 +77,8 @@ char* NAPI_CreateKey(const uint32_t keyspec, const uint32_t origin);
     }
 */
 char* NAPI_Encrypt(const char* cmk_base64,
-        const char* plaintext,
-        const char* aad);
+        const char* plaintext_base64,
+        const char* aad_base64);
 
 /*
 @return
@@ -93,7 +93,7 @@ char* NAPI_Encrypt(const char* cmk_base64,
 */
 char* NAPI_Decrypt(const char* cmk_base64,
         const char* ciphertext_base64,
-        const char* aad);
+        const char* aad_base64);
 
 /*
 @return
@@ -107,7 +107,7 @@ char* NAPI_Decrypt(const char* cmk_base64,
     }
 */
 char* NAPI_AsymmetricEncrypt(const char* cmk_base64,
-    const char* plaintext);
+    const char* plaintext_base64);
 
 /*
 @return
@@ -137,7 +137,7 @@ char* NAPI_AsymmetricDecrypt(const char* cmk_base64,
 */
 char* NAPI_GenerateDataKey(const char* cmk_base64,
         const uint32_t keylen,
-        const char* aad);
+        const char* aad_base64);
 
 /*
 @return
@@ -152,7 +152,7 @@ char* NAPI_GenerateDataKey(const char* cmk_base64,
 */
 char* NAPI_GenerateDataKeyWithoutPlaintext(const char* cmk_base64,
         const uint32_t keylen,
-        const char* aad);
+        const char* aad_base64);
 
 /*
 @return
@@ -167,7 +167,7 @@ char* NAPI_GenerateDataKeyWithoutPlaintext(const char* cmk_base64,
 */
 char* NAPI_ExportDataKey(const char* cmk_base64,
         const char* ukey_base64,
-        const char* aad,
+        const char* aad_base64,
         const char* olddatakey_base64);
 
 /*
@@ -182,7 +182,7 @@ char* NAPI_ExportDataKey(const char* cmk_base64,
     }
 */
 char* NAPI_Sign(const char* cmk_base64,
-        const char* digest);
+        const char* digest_base64);
 
 /*
 @return
@@ -196,7 +196,7 @@ char* NAPI_Sign(const char* cmk_base64,
     }
 */
 char* NAPI_Verify(const char* cmk_base64,
-        const char* digest,
+        const char* digest_base64,
         const char* signature_base64);
 
 /*

--- a/ehsm_kms_service/ehsm_kms_params.js
+++ b/ehsm_kms_service/ehsm_kms_params.js
@@ -19,11 +19,11 @@ const keyid = {
   type: 'string',
   minLength: 1,
   maxLength: MAX_LENGTH,
-  required: true,
+  required: false,
 }
 const aad = {
-  type: 'string',
-  maxLength: 32,
+  type: 'base64',
+  maxLength: MAX_LENGTH,
   required: false,
 }
 
@@ -43,9 +43,12 @@ const ehsm_kms_params = {
     },
   },
   Encrypt: {
-    keyid,
+    keyid: {
+      ...keyid, 
+      required: true
+    },
     plaintext: {
-      type: 'string',
+      type: 'base64',
       maxLength: MAX_LENGTH,
       minLength: 1,
       required: true,
@@ -53,9 +56,12 @@ const ehsm_kms_params = {
     aad,
   },
   Decrypt: {
-    keyid,
+    keyid: {
+      ...keyid, 
+      required: true
+    },
     ciphertext: {
-      type: 'string',
+      type: 'base64',
       maxLength: MAX_LENGTH,
       minLength: 1,
       required: true,
@@ -63,7 +69,10 @@ const ehsm_kms_params = {
     aad,
   },
   GenerateDataKey: {
-    keyid,
+    keyid: {
+      ...keyid, 
+      required: true
+    },
     keylen: {
       type: 'int',
       maxNum: 1024,
@@ -73,7 +82,10 @@ const ehsm_kms_params = {
     aad,
   },
   GenerateDataKeyWithoutPlaintext: {
-    keyid,
+    keyid: {
+      ...keyid, 
+      required: true
+    },
     keylen: {
       type: 'int',
       maxNum: 1024,
@@ -83,41 +95,53 @@ const ehsm_kms_params = {
     aad,
   },
   Sign: {
-    keyid,
+    keyid: {
+      ...keyid, 
+      required: true
+    },
     digest: {
-      type: 'string',
+      type: 'base64',
       maxLength: MAX_LENGTH,
       minLength: 1,
       required: true,
     },
   },
   Verify: {
-    keyid,
+    keyid: {
+      ...keyid, 
+      required: true
+    },
     digest: {
-      type: 'string',
+      type: 'base64',
       maxLength: MAX_LENGTH,
       minLength: 1,
       required: true,
     },
-    signature_base64: {
-      type: 'string',
+    signature: {
+      type: 'base64',
       maxLength: MAX_LENGTH,
       minLength: 1,
       required: true,
     },
   },
   AsymmetricEncrypt: {
-    keyid,
+    keyid: {
+      ...keyid, 
+      required: true
+    },
     plaintext: {
-      type: 'string',
+      type: 'base64',
       maxLength: MAX_LENGTH,
       minLength: 1,
       required: true,
     },
   },
   AsymmetricDecrypt: {
-    keyid,
-    ciphertext_base64: {
+    keyid: {
+      ...keyid, 
+      required: true
+    },
+    ciphertext: {
       type: 'string',
       maxLength: MAX_LENGTH,
       minLength: 1,
@@ -125,7 +149,10 @@ const ehsm_kms_params = {
     },
   },
   ExportDataKey: {
-    keyid,
+    keyid: {
+      ...keyid, 
+      required: true
+    },
     ukeyid: {
       type: 'string',
       minLength: 1,

--- a/ehsm_kms_service/router.js
+++ b/ehsm_kms_service/router.js
@@ -131,12 +131,12 @@ const router = async (p) => {
       break
     case cryptographic_apis.Verify:
       try {
-        const { keyid, digest, signature_base64 } = payload
+        const { keyid, digest, signature } = payload
         const cmk_base64 = await find_cmk_by_keyid(appid, keyid, res, DB)
         napi_res = napi_result(action, res, [
           cmk_base64,
           digest,
-          signature_base64,
+          signature,
         ])
         napi_res && res.send(napi_res)
       } catch (error) {}
@@ -151,9 +151,9 @@ const router = async (p) => {
       break
     case cryptographic_apis.AsymmetricDecrypt:
       try {
-        const { keyid, ciphertext_base64 } = payload
+        const { keyid, ciphertext } = payload
         const cmk_base64 = await find_cmk_by_keyid(appid, keyid, res, DB)
-        napi_res = napi_result(action, res, [cmk_base64, ciphertext_base64])
+        napi_res = napi_result(action, res, [cmk_base64, ciphertext])
         napi_res && res.send(napi_res)
       } catch (error) {}
       break
@@ -224,10 +224,8 @@ const router = async (p) => {
               res.send(_result(400, 'Internal error', {}))
             }
           } else {
-            res.send(_result(400, 'Internal error', {}))
+            res.send(_result(400, 'Empty quote or nonce ', {}))
           }
-        } else {
-          res.send(_result(400, 'Empty quote or nonce ', {}))
         }
       } catch (error) {}
       break

--- a/ehsm_kms_service/test/cli/asymmetric_decrypt.py
+++ b/ehsm_kms_service/test/cli/asymmetric_decrypt.py
@@ -25,7 +25,7 @@ def asymmetric_decrypt(base_url, keyid, data):
     print('encrypt data with an asymmetric cmk')
 
     payload = OrderedDict()
-    payload["ciphertext_base64"] = data
+    payload["ciphertext"] = data
     payload["keyid"] = keyid
     params = _utils_.init_params(payload)
     print('asymmetric_decrypt req:\n%s\n' %(params))
@@ -35,7 +35,7 @@ def asymmetric_decrypt(base_url, keyid, data):
         return
 
     print('asymmetric_decrypt resp:\n%s\n' %(resp.text))
-    plaintext = str(base64.b64decode(json.loads(resp.text)['result']['plaintext_base64']), 'utf-8')
+    plaintext = str(base64.b64decode(json.loads(resp.text)['result']['plaintext']), 'utf-8')
     print('asymmetric_decrypt plaintext:\n%s\n' %(plaintext))
 
 if __name__ == "__main__":

--- a/ehsm_kms_service/test/cli/decrypt.py
+++ b/ehsm_kms_service/test/cli/decrypt.py
@@ -38,7 +38,7 @@ def decrypt(base_url, keyid, data, aad):
         return
 
     print('decrypt resp:\n%s\n' %(resp.text))
-    plaintext = str(base64.b64decode(json.loads(resp.text)['result']['plaintext_base64']), 'utf-8')
+    plaintext = str(base64.b64decode(json.loads(resp.text)['result']['plaintext']), 'utf-8')
     print('decrypt plaintext:\n%s\n' %(plaintext))
 
 if __name__ == "__main__":

--- a/ehsm_kms_service/test/cli/verify.py
+++ b/ehsm_kms_service/test/cli/verify.py
@@ -28,7 +28,7 @@ def verify(base_url, keyid, digest, sig):
     payload = OrderedDict()
     payload["digest"] = digest
     payload["keyid"] = keyid
-    payload["signature_base64"] = sig
+    payload["signature"] = sig
     params = _utils_.init_params(payload)
     print('verify req:\n%s\n' %(params))
 

--- a/ehsm_kms_service/test/test_kms_with_rest.py
+++ b/ehsm_kms_service/test/test_kms_with_rest.py
@@ -100,7 +100,7 @@ def test_export_datakey(base_url, headers):
     print('CreateKey resp(EH_RSA_3072):\n%s\n' %(create_ukey_resp.text))
 
     payload.clear()
-    payload["aad"] = "test"
+    payload["aad"] = str(base64.b64encode("test".encode("utf-8")),'utf-8').upper()
     payload["keyid"] = json.loads(create_resp.text)['result']['keyid']
     payload["keylen"] = 48
     params=test_params(payload)
@@ -112,9 +112,9 @@ def test_export_datakey(base_url, headers):
 
     # test ExportDataKey
     payload.clear()
-    payload["aad"] = "test"
+    payload["aad"] = str(base64.b64encode("test".encode("utf-8")),'utf-8').upper()
     payload["keyid"] = json.loads(create_resp.text)['result']['keyid']
-    payload["olddatakey_base"] = json.loads(generateDataKeyWithoutPlaintext_resp.text)['result']['ciphertext_base64']
+    payload["olddatakey_base"] = json.loads(generateDataKeyWithoutPlaintext_resp.text)['result']['ciphertext']
     payload["ukeyid"] = json.loads(create_ukey_resp.text)['result']['keyid']
     params=test_params(payload)
     print('ExportDataKey req:\n%s\n' %(params))
@@ -140,7 +140,7 @@ def test_RSA3072_encrypt_decrypt(base_url, headers):
     # test AsymmetricEncrypt("123456")
     payload.clear()
     payload["keyid"] = json.loads(create_resp.text)['result']['keyid']
-    payload["plaintext"] = "123456"
+    payload["plaintext"] = str(base64.b64encode("123456".encode("utf-8")),'utf-8').upper()
     params=test_params(payload)
     print('AsymmetricEncrypt req:\n%s\n' %(params))
     asymmetricEncrypt_resp = requests.post(url=base_url + "AsymmetricEncrypt", data=json.dumps(params), headers=headers)
@@ -150,7 +150,7 @@ def test_RSA3072_encrypt_decrypt(base_url, headers):
 
     # test AsymmetricDecrypt(ciphertext)
     payload.clear()
-    payload["ciphertext_base64"] = json.loads(asymmetricEncrypt_resp.text)['result']['ciphertext_base64']
+    payload["ciphertext"] = json.loads(asymmetricEncrypt_resp.text)['result']['ciphertext']
     payload["keyid"] = json.loads(create_resp.text)['result']['keyid']
     params=test_params(payload)
     print('AsymmetricDecrypt req:\n%s\n' %(params))
@@ -159,7 +159,7 @@ def test_RSA3072_encrypt_decrypt(base_url, headers):
         return
     print('AsymmetricDecrypt resp:\n%s\n' %(asymmetricDecrypt_resp.text))
 
-    plaintext = str(base64.b64decode(json.loads(asymmetricDecrypt_resp.text)['result']['plaintext_base64']), 'utf-8').strip(b"\x00".decode())
+    plaintext = str(base64.b64decode(json.loads(asymmetricDecrypt_resp.text)['result']['plaintext']), 'utf-8').strip(b"\x00".decode())
     print('AsymmetricDecrypt plaintext:\n%s\n' %(plaintext))
     print('====================test_RSA3072_encrypt_decrypt end===========================')
 
@@ -177,7 +177,7 @@ def test_Stest_RSA3072_sign_verify(base_url, headers):
 
     # test Sign
     payload.clear()
-    payload["digest"] = "test"
+    payload["digest"] = str(base64.b64encode("test".encode("utf-8")),'utf-8').upper()
     payload["keyid"] = json.loads(create_resp.text)['result']['keyid']
     params=test_params(payload)
     print('Sign req:\n%s\n' %(params))
@@ -188,9 +188,9 @@ def test_Stest_RSA3072_sign_verify(base_url, headers):
 
     # test Verify
     payload.clear()
-    payload["digest"] = "test"
+    payload["digest"] = str(base64.b64encode("test".encode("utf-8")),'utf-8').upper()
     payload["keyid"] = json.loads(create_resp.text)['result']['keyid']
-    payload["signature_base64"] = json.loads(sign_resp.text)['result']['signature_base64']
+    payload["signature"] = json.loads(sign_resp.text)['result']['signature']
     params=test_params(payload)
     print('Verify req:\n%s\n' %(params))
     verify_resp = requests.post(url=base_url + "Verify", data=json.dumps(params), headers=headers)
@@ -214,7 +214,7 @@ def test_GenerateDataKeyWithoutPlaintext(base_url, headers):
 
     # test GenerateDataKeyWithoutPlaintext
     payload.clear()
-    payload["aad"] = "test"
+    payload["aad"] = str(base64.b64encode("test".encode("utf-8")),'utf-8').upper()
     payload["keyid"] = json.loads(create_resp.text)['result']['keyid']
     payload["keylen"] = 48
     params=test_params(payload)
@@ -226,8 +226,8 @@ def test_GenerateDataKeyWithoutPlaintext(base_url, headers):
 
     # test Decrypt(cipher_datakey)
     payload.clear()
-    payload["aad"] = "test"
-    payload["ciphertext"] = json.loads(generateDataKeyWithoutPlaintext_resp.text)['result']['ciphertext_base64']
+    payload["aad"] = str(base64.b64encode("test".encode("utf-8")),'utf-8').upper()
+    payload["ciphertext"] = json.loads(generateDataKeyWithoutPlaintext_resp.text)['result']['ciphertext']
     payload["keyid"] = json.loads(create_resp.text)['result']['keyid']
     params=test_params(payload)
     print('Decrypt req:\n%s\n' %(params))
@@ -252,7 +252,7 @@ def test_GenerateDataKey(base_url, headers):
 
     # test GenerateDataKey
     payload.clear()
-    payload["aad"] = "test"
+    payload["aad"] = str(base64.b64encode("test".encode("utf-8")),'utf-8').upper()
     payload["keyid"] = json.loads(create_resp.text)['result']['keyid']
     payload["keylen"] = 16
     params=test_params(payload)
@@ -264,8 +264,8 @@ def test_GenerateDataKey(base_url, headers):
 
     # test Decrypt(cipher_datakey)
     payload.clear()
-    payload["aad"] = "test"
-    payload["ciphertext"] = json.loads(generatedatakey_resp.text)['result']['ciphertext_base64']
+    payload["aad"] = str(base64.b64encode("test".encode("utf-8")),'utf-8').upper()
+    payload["ciphertext"] = json.loads(generatedatakey_resp.text)['result']['ciphertext']
     payload["keyid"] = json.loads(create_resp.text)['result']['keyid']
     params=test_params(payload)
     print('Decrypt req:\n%s\n' %(params))
@@ -290,9 +290,9 @@ def test_AES128(base_url, headers):
 
     # test Encrypt("123456")
     payload.clear()
-    payload["aad"] = "test"
+    payload["aad"] = str(base64.b64encode("test".encode("utf-8")),'utf-8').upper()
     payload["keyid"] = json.loads(create_resp.text)['result']['keyid']
-    payload["plaintext"] = "123456"
+    payload["plaintext"] = str(base64.b64encode("123456".encode("utf-8")),'utf-8').upper()
     params=test_params(payload)
     print('Encrypt req:\n%s\n' %(params))
     encrypt_resp = requests.post(url=base_url + "Encrypt", data=json.dumps(params), headers=headers)
@@ -302,8 +302,8 @@ def test_AES128(base_url, headers):
 
     # test Decrypt(ciphertext)
     payload.clear()
-    payload["aad"] = "test"
-    payload["ciphertext"] = json.loads(encrypt_resp.text)['result']['ciphertext_base64']
+    payload["aad"] = str(base64.b64encode("test".encode("utf-8")),'utf-8').upper()
+    payload["ciphertext"] = json.loads(encrypt_resp.text)['result']['ciphertext']
     payload["keyid"] = json.loads(create_resp.text)['result']['keyid']
     params=test_params(payload)
     print('Decrypt req:\n%s\n' %(params))
@@ -312,7 +312,7 @@ def test_AES128(base_url, headers):
         return
     print('Decrypt resp:\n%s\n' %(decrypt_resp.text))
     
-    plaintext = str(base64.b64decode(json.loads(decrypt_resp.text)['result']['plaintext_base64']), 'utf-8')
+    plaintext = str(base64.b64decode(json.loads(decrypt_resp.text)['result']['plaintext']), 'utf-8')
     print('Decrypt plaintext:\n%s\n' %(plaintext))
     print('check Decrypt plaintext result with %s: %s\n' %('123456', plaintext == '123456'))
 


### PR DESCRIPTION
1. Add base64 format checking for aad and plaintext paraments
2. Remove all api keys' "_base64" suffix

fix the corresponding test cases
test: passed the unittest

Signed-off-by: panpan0721 <2271409777@qq.com>