### PR TITLE
Fix sign check error

### DIFF
--- a/ehsm_kms_service/function.js
+++ b/ehsm_kms_service/function.js
@@ -560,17 +560,9 @@ const _query_api_key = async (DB, appid) => {
       [cmk, apikey, '']
     )
     if (decypt_result) {
-      let decoded_api_key = base64_decode(decypt_result.result.plaintext)
-      if (decoded_api_key) {
-        return {
-          msg: '',
-          api_key: decoded_api_key
-        }
-      } else {
-        return {
-          msg: 'Decode key error',
-          api_key: ''
-        }
+      return {
+        msg: '',
+        api_key: decypt_result.result.plaintext
       }
     } else {
       return {


### PR DESCRIPTION
The apikey decrypted is plaintest rather than base64 encoded.

Signed-off-by: panpan0721 <2271409777@qq.com>