### PR TITLE
Add mutil-threads feature for ehsm server

### DIFF
--- a/ehsm_kms_service/couchdb.js
+++ b/ehsm_kms_service/couchdb.js
@@ -8,7 +8,7 @@ const {
   EHSM_CONFIG_COUCHDB_DB,
 } = process.env
 
-async function connectDB(server) {
+async function connectDB(app, server) {
   if (
     !EHSM_CONFIG_COUCHDB_USERNAME ||
     !EHSM_CONFIG_COUCHDB_PASSWORD ||
@@ -28,7 +28,7 @@ async function connectDB(server) {
       DB = await nanoDb.use(EHSM_CONFIG_COUCHDB_DB)
     }
     if (DB) {
-      server(DB)
+      server(app, DB)
     } else {
       console.log('couchdb connect error')
     }

--- a/ehsm_kms_service/ehsm_kms_server_m.js
+++ b/ehsm_kms_service/ehsm_kms_server_m.js
@@ -9,9 +9,8 @@ const {
 } = require('./function')
 const connectDB = require('./couchdb')
 const router = require('./router')
-
-const app = express()
-app.use(express.json())
+const cluster = require('cluster')
+const os = require('os')
 
 const PORT = process.argv.slice(2)[0] || 9000
 
@@ -62,4 +61,13 @@ const server = (app, DB) => {
     )
   })
 }
-connectDB(app, server)
+
+if (cluster.isMaster) {
+  os.cpus().forEach(() => {
+    cluster.fork();
+  })
+} else {
+  const app = express()
+  app.use(express.json())
+  connectDB(app, server)
+}


### PR DESCRIPTION
This is a feature test.

Known issue:
enroll apis are not working in mutil-threads and report error (0xE00F, SGX_QL_ATT_KEY_NOT_INITIALIZED) from native library.

How To Run:
0. run dkeyserver and dkeycache
1. export <env params> && node ehsm_kms_server.js <PORT>
2. run ehsm-kms_enroll_app <ADDRESS>
3. get appid and apikey, then modify them in test_kms_with_rest.py
4. stop ehsm_kms_server.js in step 1
5. export <env params> && node ehsm_kms_server_m.js <PORT>
6. python test_kms_with_rest.py -i <ADDRESS> -p <PORT>

Signed-off-by: panpan0721 <2271409777@qq.com>