### PR TITLE
use a fixed version of dcap libs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,8 +38,11 @@ RUN wget https://download.01.org/intel-sgx/sgx-dcap/1.12.1/linux/distro/ubuntu18
 
 # Install DCAP packages
 # DCAP repository setup
-RUN echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | tee /etc/apt/sources.list.d/intel-sgx.list \
-    && wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add -
+RUN wget https://download.01.org/intel-sgx/sgx-dcap/1.12.1/linux/distro/ubuntu18.04-server/sgx_debian_local_repo.tgz \
+    && tar xzf sgx_debian_local_repo.tgz \
+    && echo 'deb [trusted=yes arch=amd64] file:///opt/intel/sgx_debian_local_repo bionic main' | tee /etc/apt/sources.list.d/intel-sgx.list \
+    && wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add - \
+    && apt-get update
 
 RUN apt-get update &&apt-get install -y \
     libsgx-enclave-common-dev \

--- a/docs/build-instructions.md
+++ b/docs/build-instructions.md
@@ -25,7 +25,13 @@ Welcome to see the build instructions for the ehsm-kms project.
 
 * Install DCAP required packages
     ```shell
-    echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
+    cd /opt/intel
+
+    wget https://download.01.org/intel-sgx/sgx-dcap/1.12.1/linux/distro/ubuntu20.04-server/sgx_debian_local_repo.tgz
+
+    tar xzf sgx_debian_local_repo.tgz
+
+    echo 'deb [trusted=yes arch=amd64] file:///opt/intel/sgx_debian_local_repo focal main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
 
     wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
 


### PR DESCRIPTION
previously it will always use the latest dcap version, however,for the 1.31
currently there're some build error with "tdx_xxx", so we change to use a
fixed version to algin with SDK until the issue is resolved.

Signed-off-by: Yan, Shaopu <shaopu.yan@intel.com>