### PR TITLE
Using enroll api in test script

### DIFF
--- a/test/_utils_.py
+++ b/test/_utils_.py
@@ -10,10 +10,16 @@ from collections import OrderedDict
 import urllib.parse
 
 # Using a dummy appid and app key
-appid='101014d7-b274-464e-8d36-e0cc7cea7760'
-apikey = 'UXqvDSe2d1pABPSWJtzz4w3k8Y8KW1bE'
+appid=''
+apikey = ''
 
 headers = {"Content-Type":"application/json"}
+
+def init_appid_apikey(appid_user, apikey_user):
+    global appid
+    global apikey
+    appid = appid_user
+    apikey = apikey_user
 
 def init_params(payload=False):
     params = OrderedDict()

--- a/test/cli/enroll.py
+++ b/test/cli/enroll.py
@@ -28,6 +28,7 @@ def enroll(base_url):
         return
 
     print('Enroll resp:\n%s\n' %(resp.text))
+    return json.loads(resp.text)['result']['appid'], json.loads(resp.text)['result']['apikey'] 
 
 if __name__ == "__main__":
     headers = _utils_.headers

--- a/test/test_kms_with_cli.py
+++ b/test/test_kms_with_cli.py
@@ -7,11 +7,18 @@ import random
 import hmac
 from hashlib import sha256
 from collections import OrderedDict
-from cli import createkey, asymmetric_decrypt, asymmetric_encrypt, decrypt, delete_all_key, deletekey, disablekey, enablekey, encrypt, export_datakey, generate_datakey, generate_datakey_withoutplaint, generate_quote, getversion, listkey, sign, verify, verify_quote
+from cli import createkey, asymmetric_decrypt, asymmetric_encrypt, decrypt, delete_all_key, deletekey, disablekey, enablekey, encrypt, export_datakey, generate_datakey, generate_datakey_withoutplaint, generate_quote, getversion, listkey, sign, verify, verify_quote, enroll
 import urllib.parse
-appid= '468c507a-da1f-4127-9cd0-82f0e7ce247e'
-apikey= 'Merh0HrKuc2e8ECt5qba5dhy0ykyp1Js'
+import _utils_
+appid= ''
+apikey= ''
 keyid= ''
+
+def get_appid_apikey(base_url):
+    global appid
+    global apikey
+    appid, apikey = enroll.enroll(base_url)
+    _utils_.init_appid_apikey(appid, apikey)
 
 def test_disableKey(base_url, headers):
     disablekey.disablekey(base_url, keyid)
@@ -144,6 +151,8 @@ if __name__ == "__main__":
     url = get_args()
 
     base_url = url + "/ehsm?Action="
+
+    get_appid_apikey(base_url)
     
     test_AES128(base_url, headers)
 


### PR DESCRIPTION
Using enroll restful api to get appid and apikey in test script

Signed-off-by: Long Hanyu <hanyu.long@intel.com>