### PR TITLE
Implement aes_gcm_128/256 encryption inerfaces with SGX-SSL

### DIFF
--- a/License.txt
+++ b/License.txt
@@ -1,0 +1,31 @@
+BSD 3-clause "New" or "Revised" License
+
+Copyright (C) 2020-2022 Intel Corporation. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+  * Neither the name of Intel Corporation nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=================================================================

--- a/core/App/ehsm_provider.cpp
+++ b/core/App/ehsm_provider.cpp
@@ -141,18 +141,21 @@ ehsm_status_t CreateKey(ehsm_keyblob_t *cmk)
 
     switch (cmk->metadata.keyspec) {
         case EH_AES_GCM_128:
+        case EH_AES_GCM_256:
             if (cmk->keybloblen == 0) {
                 ret = enclave_create_aes_key(g_enclave_id,
-                                         &sgxStatus,
-                                         NULL,
-                                         0,
-                                         &(cmk->keybloblen));
+                                             &sgxStatus,
+                                             NULL,
+                                             0,
+                                             &(cmk->keybloblen),
+                                             (ehsm_keyspec_t)cmk->metadata.keyspec);
             } else {
                 ret = enclave_create_aes_key(g_enclave_id,
-                                         &sgxStatus,
-                                         cmk->keyblob,
-                                         cmk->keybloblen,
-                                         NULL);
+                                             &sgxStatus,
+                                             cmk->keyblob,
+                                             cmk->keybloblen,
+                                             NULL,
+                                             (ehsm_keyspec_t)cmk->metadata.keyspec);
             }
             break;
         case EH_RSA_3072:
@@ -194,6 +197,7 @@ ehsm_status_t Encrypt(ehsm_keyblob_t *cmk,
 
     /* this api only support for symmetric keys */
     if (cmk->metadata.keyspec != EH_AES_GCM_128 &&
+        cmk->metadata.keyspec != EH_AES_GCM_256 &&
         cmk->metadata.keyspec != EH_SM4) {
         return EH_KEYSPEC_INVALID;
     }
@@ -206,6 +210,7 @@ ehsm_status_t Encrypt(ehsm_keyblob_t *cmk,
 
     switch(cmk->metadata.keyspec) {
         case EH_AES_GCM_128:
+        case EH_AES_GCM_256:
             /* calculate the ciphertext length */
             if (ciphertext->datalen == 0) {
                 ciphertext->datalen = plaintext->datalen + EH_AES_GCM_IV_SIZE + EH_AES_GCM_MAC_SIZE;
@@ -225,15 +230,16 @@ ehsm_status_t Encrypt(ehsm_keyblob_t *cmk,
             }
 
             ret = enclave_aes_encrypt(g_enclave_id,
-                                  &sgxStatus,
-                                  aad->data,
-                                  aad->datalen,
-                                  cmk->keyblob,
-                                  cmk->keybloblen,
-                                  plaintext->data,
-                                  plaintext->datalen,
-                                  ciphertext->data,
-                                  ciphertext->datalen);
+                                      &sgxStatus,
+                                      aad->data,
+                                      aad->datalen,
+                                      cmk->keyblob,
+                                      cmk->keybloblen,
+                                      plaintext->data,
+                                      plaintext->datalen,
+                                      ciphertext->data,
+                                      ciphertext->datalen,
+                                      (ehsm_keyspec_t)cmk->metadata.keyspec);
             break;
         case EH_SM4:
             //TODO
@@ -332,6 +338,7 @@ ehsm_status_t Decrypt(ehsm_keyblob_t *cmk,
 
     /* this api only support for symmetric keys */
     if (cmk->metadata.keyspec != EH_AES_GCM_128 &&
+        cmk->metadata.keyspec != EH_AES_GCM_256 &&
         cmk->metadata.keyspec != EH_SM4) {
         return EH_KEYSPEC_INVALID;
     }
@@ -342,6 +349,7 @@ ehsm_status_t Decrypt(ehsm_keyblob_t *cmk,
 
     switch(cmk->metadata.keyspec) {
         case EH_AES_GCM_128:
+        case EH_AES_GCM_256:
             /* calculate the ciphertext length */
             if (plaintext->datalen == 0) {
                 plaintext->datalen = ciphertext->datalen - EH_AES_GCM_IV_SIZE - EH_AES_GCM_MAC_SIZE;
@@ -361,15 +369,16 @@ ehsm_status_t Decrypt(ehsm_keyblob_t *cmk,
             }
 
             ret = enclave_aes_decrypt(g_enclave_id,
-                                  &sgxStatus,
-                                  aad->data,
-                                  aad->datalen,
-                                  cmk->keyblob,
-                                  cmk->keybloblen,
-                                  ciphertext->data,
-                                  ciphertext->datalen,
-                                  plaintext->data,
-                                  plaintext->datalen);
+                                      &sgxStatus,
+                                      aad->data,
+                                      aad->datalen,
+                                      cmk->keyblob,
+                                      cmk->keybloblen,
+                                      ciphertext->data,
+                                      ciphertext->datalen,
+                                      plaintext->data,
+                                      plaintext->datalen,
+                                      (ehsm_keyspec_t)cmk->metadata.keyspec);
             break;
         case EH_SM4:
             //TODO

--- a/core/App/ehsm_provider.h
+++ b/core/App/ehsm_provider.h
@@ -86,17 +86,6 @@ typedef enum  {
 } ehsm_keyorigin_t;
 
 typedef enum {
-    EH_AES_GCM_128 = 0,
-    EH_AES_GCM_256 =1,
-    EH_RSA_2048 = 2,
-    EH_RSA_3072 = 3,
-    EH_EC_P256 = 4,
-    EH_EC_P512 = 5,
-    EH_EC_SM2 =6,
-    EH_SM4 =7,
-} ehsm_keyspec_t;
-
-typedef enum {
     ENCRYPT_DECRYPT = 0,
     SIGN_VERIFY = 1,
 } ehsm_keypurpose_t;

--- a/core/Enclave/enclave_hsm.edl
+++ b/core/Enclave/enclave_hsm.edl
@@ -68,17 +68,17 @@ enclave {
     trusted {
         /* Interfaces for eHSM core crypto functions */
         public sgx_status_t enclave_create_aes_key([out, size=cmk_blob_size] uint8_t *cmk_blob,
-                uint32_t cmk_blob_size, [out] uint32_t *req_blob_size);
+                uint32_t cmk_blob_size, [out] uint32_t *req_blob_size, ehsm_keyspec_t keyspec);
 
         public sgx_status_t enclave_aes_encrypt([in, size=aad_len] const uint8_t *aad, size_t aad_len,
                 [in, size=cmk_blob_size] const uint8_t *cmk_blob, size_t cmk_blob_size,
                 [in, size=plaintext_len] const uint8_t *plaintext, size_t plaintext_len,
-                [out, size=cipherblob_len] uint8_t *cipherblob, size_t cipherblob_len);
+                [out, size=cipherblob_len] uint8_t *cipherblob, size_t cipherblob_len, ehsm_keyspec_t keyspec);
 
         public sgx_status_t enclave_aes_decrypt([in, size=aad_len] const uint8_t *aad, size_t aad_len,
                 [in, size=cmk_blob_size] const uint8_t *cmk_blob, size_t cmk_blob_size,
                 [in, size=cipherblob_len] const uint8_t *cipherblob, size_t cipherblob_len,
-                [out, size=plaintext_len] uint8_t *plaintext, size_t plaintext_len);
+                [out, size=plaintext_len] uint8_t *plaintext, size_t plaintext_len, ehsm_keyspec_t keyspec);
 
         public sgx_status_t enclave_generate_datakey(uint32_t key_spec,
                 [in, size=cmk_blob_size] const uint8_t *cmk_blob, size_t cmk_blob_size,

--- a/ehsm_kms_service/function.js
+++ b/ehsm_kms_service/function.js
@@ -264,8 +264,11 @@ const enroll_user_info = (action, DB, res, req) => {
   if (napi_res) {
     const { appid, apikey } = napi_res.result
     let cmk_res = napi_result(cryptographic_apis.CreateKey, res, [0, 0])
-    if (cmk_res) {
+    let sm_default_cmk_res = napi_result(cryptographic_apis.CreateKey, res, [0, 0])
+    if (cmk_res && sm_default_cmk_res) {
       const { cmk } = cmk_res.result
+      // create a default secret manager CMK for current appids
+      const sm_default_cmk = sm_default_cmk_res.result.cmk
       let apikey_encrypt_res = napi_result(cryptographic_apis.Encrypt, res, [
         cmk,
         apikey,
@@ -278,6 +281,7 @@ const enroll_user_info = (action, DB, res, req) => {
           appid,
           apikey: ciphertext,
           cmk: cmk,
+          sm_default_cmk,
         })
           .then((r) => {
             res.send(_result(200, 'successful', { ...napi_res.result }))
@@ -286,6 +290,8 @@ const enroll_user_info = (action, DB, res, req) => {
             res.send(_result(400, 'enroll user info faild', e))
           })
       }
+    } else {
+      res.send(_result(400, 'enroll user info faild'))
     }
   }
 }

--- a/include/datatypes.h
+++ b/include/datatypes.h
@@ -134,6 +134,17 @@ typedef struct _session_id_tracker_t
     uint32_t          session_id;
 } session_id_tracker_t;
 
+typedef enum {
+    EH_AES_GCM_128 = 0,
+    EH_AES_GCM_256,
+    EH_RSA_2048,
+    EH_RSA_3072,
+    EH_EC_P256,
+    EH_EC_P512,
+    EH_EC_SM2,
+    EH_SM4,
+} ehsm_keyspec_t;
+
 #pragma pack(pop)
 
 


### PR DESCRIPTION
Use the SGX-SSL interface when using thr AES128/256 key for encryption
and decryption

add the corresponding test cases

test: passed the core test

Signed-off-by: wanghaiheng <wanghaiheng@neusoft.com>