### PR TITLE
add support for the updateSecretDesc restful API

### DIFF
--- a/ehsm_kms_service/apis.js
+++ b/ehsm_kms_service/apis.js
@@ -33,6 +33,7 @@ const key_management_apis = {
 
 const secret_manager_apis = {
   CreateSecret: 'CreateSecret',
+  UpdateSecretDesc: 'UpdateSecretDesc'
 }
 
 const common_apis = {

--- a/ehsm_kms_service/router.js
+++ b/ehsm_kms_service/router.js
@@ -25,6 +25,7 @@ const {
 } = require('./key_management_apis')
 const {
   createSecret,
+  updateSecretDesc
 } = require('./secret_manager_apis')
 /**
  *
@@ -254,6 +255,9 @@ const router = async (p) => {
       break
     case secret_manager_apis.CreateSecret:
         createSecret(res, appid, payload, DB)
+      break
+    case secret_manager_apis.UpdateSecretDesc:
+        updateSecretDesc(res, appid, payload, DB)
       break
     default:
       res.send(_result(404, 'API Not Found', {}))

--- a/test/cli/updateSecretDesc.py
+++ b/test/cli/updateSecretDesc.py
@@ -1,0 +1,48 @@
+import requests
+import json
+import argparse
+import base64
+import time
+import random
+import hmac
+from hashlib import sha256
+from collections import OrderedDict
+import urllib.parse
+
+import _utils_
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--url', type=str, help='the address of the ehsm_kms_server', required=True)
+    parser.add_argument('--secretName', type=str, help='the name of the secret', required=True)
+    parser.add_argument('--description', type=str, help='the description of the secret')
+    args = parser.parse_args()
+
+    base_url = args.url + "/ehsm?Action="
+    print(base_url)
+    return base_url, args.secretName, args.description
+
+def updateSecretDesc(base_url, secretName, description = None):
+    print('update secret description')
+    
+    payload = OrderedDict()
+    if description != None:
+        payload["description"] = description
+    payload["secretName"] = secretName
+    params = _utils_.init_params(payload)
+    print('update Secret req:\n%s\n' %(params))
+    
+    resp = requests.post(url=base_url + "UpdateSecretDesc", data=json.dumps(params), headers=_utils_.headers, verify=_utils_.use_secure_cert)
+    if(_utils_.check_result(resp, 'UpdateSecretDesc') == False):
+        return
+    print('updateSecretDesc resp:\n%s\n' %(resp.text))
+
+
+if __name__ == "__main__":
+    headers = _utils_.headers
+
+    base_url, secretName, description = get_args()
+
+    updateSecretDesc(base_url, secretName, description)
+

--- a/test/test_secret_manager_with_cli.py
+++ b/test/test_secret_manager_with_cli.py
@@ -8,7 +8,7 @@ import hmac
 import os
 from hashlib import sha256
 from collections import OrderedDict
-from cli import createkey, enroll, createSecret
+from cli import createkey, enroll, createSecret, updateSecretDesc
 import urllib.parse
 import _utils_
 appid= ''
@@ -29,6 +29,8 @@ def test_secret_manager(base_url, headers):
     createSecret.createSecret(base_url, "secretData1", "secret001", key1, "mysecret", "30h")
 
     createSecret.createSecret(base_url, "secretData2", "secret002", None, "mysecret", "20d")
+
+    updateSecretDesc.updateSecretDesc(base_url, "secret001", "myNewSecret")
 
     print('====================test_secret_manager end===========================')
 


### PR DESCRIPTION
this restful API will be exposed to public as:
POST <ehsm_srv_address>/ehsm?Action=UpdateSecretDesc

which is used to update the description of secret.

test: passed the unittest

Signed-off-by: yidingluo1 <luo.yd@neusoft.com>