### PR TITLE
add support for the DescribeSecret restful API

### DIFF
--- a/ehsm_kms_service/apis.js
+++ b/ehsm_kms_service/apis.js
@@ -33,6 +33,7 @@ const key_management_apis = {
 
 const secret_manager_apis = {
   CreateSecret: 'CreateSecret',
+  DescribeSecret: 'DescribeSecret',
 }
 
 const common_apis = {

--- a/ehsm_kms_service/router.js
+++ b/ehsm_kms_service/router.js
@@ -25,6 +25,7 @@ const {
 } = require('./key_management_apis')
 const {
   createSecret,
+  describeSecret,
 } = require('./secret_manager_apis')
 /**
  *
@@ -254,6 +255,9 @@ const router = async (p) => {
       break
     case secret_manager_apis.CreateSecret:
         createSecret(res, appid, payload, DB)
+      break
+    case secret_manager_apis.DescribeSecret:
+        describeSecret(res, appid, payload, DB)
       break
     default:
       res.send(_result(404, 'API Not Found', {}))

--- a/test/cli/describeSecret.py
+++ b/test/cli/describeSecret.py
@@ -1,0 +1,45 @@
+import requests
+import json
+import argparse
+import base64
+import time
+import random
+import hmac
+from hashlib import sha256
+from collections import OrderedDict
+import urllib.parse
+
+import _utils_
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--url', type=str, help='the address of the ehsm_kms_server', required=True)
+    parser.add_argument('--secretName', type=str, help='the name of the secret', required=True)
+    args = parser.parse_args()
+
+    base_url = args.url + "/ehsm?Action="
+    print(base_url)
+    return base_url, args.secretName
+
+def describeSecret(base_url, secretName):
+    payload = OrderedDict()
+    payload["secretName"] = secretName
+    params = _utils_.init_params(payload)
+    print('describeSecret req:\n%s\n' %(params))
+
+    resp = requests.post(url=base_url + "DescribeSecret", data=json.dumps(params), headers=_utils_.headers, verify=_utils_.use_secure_cert)
+    if(_utils_.check_result(resp, 'DescribeSecret') == False):
+        return
+
+    print('describeSecret resp:\n%s\n' %(resp.text))
+    if ('secretName' in json.loads(resp.text)['result']):
+        secretName = json.loads(resp.text)['result']['secretName']
+    return secretName
+
+if __name__ == "__main__":
+    headers = _utils_.headers
+
+    base_url, secretName = get_args()
+
+    describeSecret(base_url, secretName)
+

--- a/test/test_secret_manager_with_cli.py
+++ b/test/test_secret_manager_with_cli.py
@@ -8,7 +8,7 @@ import hmac
 import os
 from hashlib import sha256
 from collections import OrderedDict
-from cli import createkey, enroll, createSecret
+from cli import createkey, enroll, createSecret, describeSecret
 import urllib.parse
 import _utils_
 appid= ''
@@ -29,6 +29,9 @@ def test_secret_manager(base_url, headers):
     createSecret.createSecret(base_url, "secretData1", "secret001", key1, "mysecret", "30h")
 
     createSecret.createSecret(base_url, "secretData2", "secret002", None, "mysecret", "20d")
+
+    describeSecret_secretName = describeSecret.describeSecret(base_url, "secret001")
+    print('check describeSecret result with %s: %s\n' %('secretName', describeSecret_secretName == "secret001"))
 
     print('====================test_secret_manager end===========================')
 


### PR DESCRIPTION
 this restful API will be exposed to public as:
 POST <ehsm_srv_address>/ehsm?Action=DescribeSecret

 Obtains the metadata of a secret.

 test: passed the python test

Signed-off-by: wanghouqi <wanghouqi@vip.qq.com>