### PR TITLE
add support for rsa createKey/encrypy/decrypt with sgx-ssl api

### DIFF
--- a/core/App/ehsm_provider.h
+++ b/core/App/ehsm_provider.h
@@ -44,28 +44,12 @@
 
 #define ENCLAVE_PATH "libenclave-ehsm-core.signed.so"
 
-#define EH_ENCRYPT_MAX_SIZE (6*1024)
-
 #define EH_AAD_MAX_SIZE (8*1024)
 
 #define EH_QUOTE_MAX_SIZE (8*1024)
 
-#define EH_CMK_MAX_SIZE (4*1024)
+#define EH_CMK_MAX_SIZE (8*1024)
 
-#define EH_DATA_KEY_MAX_SIZE 1024
-
-#define EH_AES_GCM_IV_SIZE  12
-#define EH_AES_GCM_MAC_SIZE 16
-
-#define RSA_OAEP_2048_SHA_256_MAX_ENCRYPTION_SIZE       190
-// #define RSA_2048_OAEP_SHA_1_MAX_ENCRYPTION_SIZE       214
-
-#define RSA_OAEP_3072_SHA_256_MAX_ENCRYPTION_SIZE       318
-// #define RSA_3072_OAEP_SHA_1_MAX_ENCRYPTION_SIZE       342
-
-#define SM2PKE_MAX_ENCRYPTION_SIZE                      6047
-
-#define RSA_OAEP_3072_CIPHER_LENGTH       384
 #define RSA_OAEP_3072_SIGNATURE_SIZE      384
 #define RSA_OAEP_3072_DIGEST_SIZE         256
 


### PR DESCRIPTION
it can create rsa key and length is 2048 or 3072
padding mode supports RSA_PKCS1_PADDING and RSA_PKCS1_OAEP_PADDING

add test case for rsa_2048/3072_encrypt/decrypt

test: passed the unit test

Signed-off-by: wanghaiheng <wanghaiheng@neusoft.com>