### PR TITLE
Remove sgx mounts of k8s

### DIFF
--- a/docker/k8s/ehsm-kms-dkeyserver.yaml
+++ b/docker/k8s/ehsm-kms-dkeyserver.yaml
@@ -46,16 +46,6 @@ spec:
       labels:
         app: main
     spec:
-      volumes:
-      - name: dev-enclave
-        hostPath:
-          path: /dev/sgx/enclave
-      - name: dev-provision
-        hostPath:
-          path: /dev/sgx/provision
-      - name: dev-aesmd
-        hostPath:
-          path: /var/run/aesmd
       containers:
       - name: main
         image: intel/dkeyserver:latest
@@ -72,13 +62,6 @@ spec:
         #     path: /isLive
         #   initialDelaySeconds: 5
         #   periodSeconds: 10
-        volumeMounts:
-        - mountPath: /dev/sgx/enclave
-          name: dev-enclave
-        - mountPath: /dev/sgx/provision
-          name: dev-provision
-        - mountPath: /var/run/aesmd
-          name: dev-aesmd
         env:
         - name: PCCS_URL 
           valueFrom:
@@ -111,16 +94,6 @@ spec:
       labels:
         app: worker
     spec:
-      volumes:
-      - name: dev-enclave
-        hostPath:
-          path: /dev/sgx/enclave
-      - name: dev-provision
-        hostPath:
-          path: /dev/sgx/provision
-      - name: dev-aesmd
-        hostPath:
-          path: /var/run/aesmd
       # initContainers:
       # - name: init-worker
       #   # this images same the container's image.
@@ -152,13 +125,6 @@ spec:
         #   periodSeconds: 10
         securityContext:
           privileged: true
-        volumeMounts:
-        - mountPath: /dev/sgx/enclave
-          name: dev-enclave
-        - mountPath: /dev/sgx/provision
-          name: dev-provision
-        - mountPath: /var/run/aesmd
-          name: dev-aesmd
         env:
         - name: PCCS_URL 
           valueFrom:

--- a/docker/k8s/ehsm-kms.yaml
+++ b/docker/k8s/ehsm-kms.yaml
@@ -149,15 +149,6 @@ spec:
         name: dkeycache
     spec:
       volumes:
-      - name: dev-enclave
-        hostPath:
-          path: /dev/sgx/enclave
-      - name: dev-provision
-        hostPath:
-          path: /dev/sgx/provision
-      - name: dev-aesmd
-        hostPath:
-          path: /var/run/aesmd
       - name: dev-dkeyprovision
         hostPath:
           path: /var/run/ehsm
@@ -168,12 +159,6 @@ spec:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /dev/sgx/enclave
-          name: dev-enclave
-        - mountPath: /dev/sgx/provision
-          name: dev-provision
-        - mountPath: /var/run/aesmd
-          name: dev-aesmd
         - mountPath: /var/run/ehsm
           name: dev-dkeyprovision
         env:
@@ -211,15 +196,6 @@ spec:
         app: ehsm-kms
     spec:
       volumes:
-      - name: dev-enclave
-        hostPath:
-          path: /dev/sgx/enclave
-      - name: dev-provision
-        hostPath:
-          path: /dev/sgx/provision
-      - name: dev-aesmd
-        hostPath:
-          path: /var/run/aesmd
       - name: dev-dkeyprovision
         hostPath:
           path: /var/run/ehsm
@@ -247,12 +223,6 @@ spec:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /dev/sgx/enclave
-          name: dev-enclave
-        - mountPath: /dev/sgx/provision
-          name: dev-provision
-        - mountPath: /var/run/aesmd
-          name: dev-aesmd
         - mountPath: /var/run/ehsm
           name: dev-dkeyprovision
         env:


### PR DESCRIPTION
  remove sgx mounts of k8s, Because K8S natively supports sgx.

Signed-off-by: wanghouqi <wanghouqi@vip.qq.com>