### PR TITLE
Config the CouchDB to run as single node mode in K8S

### DIFF
--- a/docker/k8s/ehsm-kms.yaml
+++ b/docker/k8s/ehsm-kms.yaml
@@ -98,6 +98,13 @@ spec:
       - name: couchdb
         image: couchdb:3.2
         imagePullPolicy: IfNotPresent
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - sh
+              - -c
+              - "echo [couchdb] single_node=true >> /opt/couchdb/etc/local.d/docker.ini; echo [couchdb] single_node=true >> /opt/couchdb/etc/local.ini"
         readinessProbe:
           httpGet:
             port: couchdb-port


### PR DESCRIPTION
Config the CouchDB to run as single node mode in K8S

passed all the unit-test

Signed-off-by: wanghouqi <houqix.wang@intel.com>