### PR TITLE
Add safe-test for asymmetric key pair

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -107,6 +107,11 @@ ifeq ($(ENABLE_SELF_TEST), 1)
 	Enclave_C_Flags += -DENABLE_SELF_TEST
 endif
 
+ENABLE_PAIR_WISE_TEST ?= 0
+ifeq ($(ENABLE_PAIR_WISE_TEST), 1)
+	Enclave_C_Flags += -ENABLE_PAIR_WISE_TEST
+endif
+
 Enclave_Cpp_Flags := $(Enclave_C_Flags) -std=c++11 -nostdinc++ -include "tsgxsslio.h"
 
 # To generate a proper enclave, it is recommended to follow below guideline to link the trusted libraries:


### PR DESCRIPTION
Add safe-test for asymmetric key pair

the safe-test will support for:
rsa: generate key pair
ecc: generate key pair
sm2: generate key pair

test: passed all the unit test
Signed-off-by: wanghaiheng <haihengx.wang@intel.com>