### PR TITLE
Use calloc to zero the memory of apikey buffer

### DIFF
--- a/core/App/ffi_operation.cpp
+++ b/core/App/ffi_operation.cpp
@@ -1432,7 +1432,7 @@ extern "C"
         }
         appid->datalen = UUID_STR_LEN;
 
-        apikey = (ehsm_data_t *)malloc(APPEND_SIZE_TO_DATA_T(EH_API_KEY_SIZE + 1));
+        apikey = (ehsm_data_t *)calloc(APPEND_SIZE_TO_DATA_T(EH_API_KEY_SIZE + 1), sizeof(uint8_t));
         if (apikey == NULL)
         {
             ret = EH_DEVICE_MEMORY;


### PR DESCRIPTION
test: passed the unit test

Signed-off-by: luoyiding <yidingx.luo@intel.com>