### PR TITLE
Return a fixed length of plaintext for RSA decryption

### DIFF
--- a/core/Enclave/key_operation.cpp
+++ b/core/Enclave/key_operation.cpp
@@ -701,6 +701,7 @@ sgx_status_t ehsm_rsa_decrypt(const ehsm_keyblob_t *cmk,
                               ehsm_data_t *plaintext)
 {
     sgx_status_t ret = SGX_ERROR_UNEXPECTED;
+    int retval = 0;
 
     // verify padding mode
     if (cmk->metadata.padding_mode != EH_PAD_RSA_PKCS1 && cmk->metadata.padding_mode != EH_PAD_RSA_PKCS1_OAEP)
@@ -738,26 +739,22 @@ sgx_status_t ehsm_rsa_decrypt(const ehsm_keyblob_t *cmk,
 
     if (plaintext->datalen == 0)
     {
-        uint8_t temp_plaintext[RSA_size(rsa_prikey)] = {0};
-        plaintext->datalen = RSA_private_decrypt(ciphertext->datalen,
-                                                 ciphertext->data,
-                                                 temp_plaintext,
-                                                 rsa_prikey,
-                                                 cmk->metadata.padding_mode);
+        plaintext->datalen = RSA_size(rsa_prikey);
         ret = SGX_SUCCESS;
         goto out;
     }
-
-    if (!RSA_private_decrypt(ciphertext->datalen,
-                             ciphertext->data,
-                             plaintext->data,
-                             rsa_prikey,
-                             cmk->metadata.padding_mode))
+    retval = RSA_private_decrypt(ciphertext->datalen,
+                                     ciphertext->data,
+                                     plaintext->data,
+                                     rsa_prikey,
+                                     cmk->metadata.padding_mode);
+    if (retval <= 0)
     {
         log_d("failed to make rsa decrypt\n");
         ret = SGX_ERROR_UNEXPECTED;
         goto out;
     }
+    plaintext->datalen = retval;
 
 out:
     BIO_free(bio);


### PR DESCRIPTION
Previously, when the input of datalen for the plaintext is zero, it will
calculate the actual size of the plaintext buffer by performing one extra
time of rsa decryption. However, we can return a fixed buffer size directly
to the user to reduce unnecessary calculations.

Signed-off-by: panqiang <qiangx.pan@intel.com>