### PR TITLE
Fix some issues in nodejs

### DIFF
--- a/ehsm_kms_service/ehsm_kms_server.js
+++ b/ehsm_kms_service/ehsm_kms_server.js
@@ -87,6 +87,10 @@ const server = (DB) => {
         process.exit(0)
     })
 
+    process.on('uncaughtException', function (err) {
+        console.log(err)
+    });
+
     // process open ssl
     try {
         const {


### PR DESCRIPTION
Some exceptions uncaught will cause the kms service to crash. After fixed, can catch these exceptions.

test: pass the fuzz test

Signed-off-by: luoyiding <yidingx.luo@intel.com>