### PR TITLE
fix dkeycache will use 100%cpu core in docker

### DIFF
--- a/dkeycache/App/la_server.cpp
+++ b/dkeycache/App/la_server.cpp
@@ -105,6 +105,7 @@ void LaServer::doWork()
     
     while (!m_shutdown)
     {
+        sleep(1); // it is to fix dkeycache will use 100%cpu core in docker
         // set 20s timeout for select() 
         tv.tv_sec = 20;
         tv.tv_usec = 0;


### PR DESCRIPTION
test: pass docker

Signed-off-by: wanghouqi <houqix.wang@intel.com>