### PR TITLE
add initial support for go client sdk

### DIFF
--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -1,0 +1,93 @@
+package ehsm
+
+import (
+    tls "crypto/tls"
+    "encoding/json"
+    "fmt"
+    http "net/http"
+    "sort"
+    "os"
+    "bytes"
+    "sync"
+
+    "github.com/iancoleman/orderedmap"
+)
+
+type Client struct {
+    modifyLock              sync.RWMutex
+    addr                    string
+    apikey                  string
+    appid                   string
+    action                  string
+    resquest                *orderedmap.OrderedMap
+}
+
+// For production environment, the web server should request a formally issued
+// certificate, and change the below skipVerify to False.
+const skipVerify = true
+
+func NewClient() (*Client, error) {
+    c := new(Client)
+    c.modifyLock.Lock()
+    defer c.modifyLock.Unlock()
+
+    c.addr = os.Getenv("EHSM_ADDR")
+    if c.addr == "" {
+        return nil, fmt.Errorf("Please export EHSM_ADDR.")
+    }
+    c.appid = os.Getenv("EHSM_APPID")
+    if c.appid == "" {
+        return nil, fmt.Errorf("Please export EHSM_APPID.")
+    }
+    c.apikey = os.Getenv("EHSM_APIKEY")
+    if c.apikey == "" {
+        return nil, fmt.Errorf("Please export EHSM_APIKEY.")
+    }
+
+    return c, nil
+}
+
+func (c *Client) ehsmHttpAction() (*http.Response, error) {
+    // create an insecure Transport
+    tr := &http.Transport{
+        TLSClientConfig: &tls.Config{InsecureSkipVerify: skipVerify},
+    }
+
+    // create an insecure Client
+    client := &http.Client{Transport: tr}
+
+    requestBody, err := json.Marshal(c.resquest)
+    
+    // call ehsm kms
+    resp, err := client.Post(c.addr + "/ehsm?Action=" + c.action, "application/json", bytes.NewBuffer(requestBody))
+
+    return resp, err
+}
+
+func sortMap(oldmap *orderedmap.OrderedMap) *orderedmap.OrderedMap {
+    newmap := orderedmap.New()
+    keys := oldmap.Keys()
+    sort.Strings(keys)
+    for _, key := range keys {
+        value, _ := oldmap.Get(key)
+        newmap.Set(key, value)
+    }
+    return newmap
+}
+func paramsSortStr(signParams *orderedmap.OrderedMap) string {
+    var str string
+    sortedSignParams := sortMap(signParams)
+    for _, k := range sortedSignParams.Keys() {
+        v, _ := sortedSignParams.Get(k)
+        if k == "payload" {
+            payload := v.(*orderedmap.OrderedMap)
+            str += "&" + k + "=" + paramsSortStr(payload)
+        } else {
+            str += fmt.Sprintf("&%s=%v", k, v)
+        }
+    }
+    if len(str) > 0 {
+        str = str[1:] // Remove leading "&"
+    }
+    return str
+}

--- a/sdk/go/createkey.go
+++ b/sdk/go/createkey.go
@@ -1,0 +1,94 @@
+package ehsm
+
+import (
+    hmac "crypto/hmac"
+    sha256 "crypto/sha256"
+    "encoding/base64"
+    "encoding/json"
+    "fmt"
+    ioutil "io/ioutil"
+    "time"
+    "strconv"
+
+    "github.com/iancoleman/orderedmap"
+)
+
+type CreateKeyResponse struct {
+    Code int `json:"code"`
+    Message string `json:"message"`
+    Result struct {
+        Keyid string `json:"keyid"`
+    } `json:"result"`
+}
+
+func (c *Client) CreateKey(keyspec, origin, purpose, padding_mode string) (string, error){
+    // make JSON for createkey
+    payload := orderedmap.New()
+    if keyspec != ""{
+        payload.Set("keyspec", keyspec)
+    } else {
+        return "", fmt.Errorf("Please input keyspec.")
+    }
+    if origin != ""{
+        payload.Set("origin", origin)
+    } else {
+        return "", fmt.Errorf("Please input origin.")
+    }
+
+    if purpose != ""{
+        payload.Set("purpose", purpose)
+    }
+    if padding_mode != ""{
+        payload.Set("padding_mode", padding_mode)
+    }
+    
+    params := orderedmap.New()
+    params.Set("appid", c.appid)
+    params.Set("payload", payload)
+    params.Set("timestamp", strconv.FormatInt(time.Now().UnixNano()/int64(time.Millisecond), 10))
+
+    signString := paramsSortStr(params)
+    hmacSha256 := hmac.New(sha256.New, []byte(c.apikey))
+    hmacSha256.Write([]byte(signString))
+    sign := base64.StdEncoding.EncodeToString(hmacSha256.Sum(nil))
+
+    params.Set("sign", sign)
+
+    c.modifyLock.Lock()
+    defer c.modifyLock.Unlock()
+
+    c.action = "CreateKey"
+    c.resquest = params
+
+    // call ehsm kms
+    resp, err := c.ehsmHttpAction()
+    if err != nil {
+        fmt.Println("ehsmHttpAction error:", err)
+        return "", err
+    }
+
+    defer resp.Body.Close()
+
+    body, err := ioutil.ReadAll(resp.Body)
+    if err != nil {
+        fmt.Println("ReadAll error:", err)
+        return "", err
+    }
+
+    // parse response for cosign
+    var createKeyResponse CreateKeyResponse
+
+    str := string(body)
+
+    err = json.Unmarshal([]byte(str), &createKeyResponse)
+    if err != nil{
+        fmt.Println("Unmarshal error:", err)
+        return "", err
+    }
+
+    if createKeyResponse.Code != 200 {
+        return "", fmt.Errorf(createKeyResponse.Message)
+    }
+
+    return createKeyResponse.Result.Keyid, nil
+}

--- a/sdk/go/getpublickey.go
+++ b/sdk/go/getpublickey.go
@@ -1,0 +1,113 @@
+package ehsm
+
+import (
+    "crypto"
+    hmac "crypto/hmac"
+    sha256 "crypto/sha256"
+    "encoding/base64"
+    "encoding/json"
+    "fmt"
+    ioutil "io/ioutil"
+    "time"
+    "strconv"
+    "errors"
+    "crypto/x509"
+    "encoding/pem"
+
+    "github.com/iancoleman/orderedmap"
+)
+
+type GetPublicKeyResponse struct {
+    Code int `json:"code"`
+    Message string `json:"message"`
+    Result struct {
+        Keyid string `json:"keyid"`
+        Pubkey string `json:"pubkey"`
+    } `json:"result"`
+}
+
+type PEMType string
+
+const (
+    // PublicKeyPEMType is the string "PUBLIC KEY" to be used during PEM encoding and decoding
+    PublicKeyPEMType PEMType = "PUBLIC KEY"
+    // PKCS1PublicKeyPEMType is the string "RSA PUBLIC KEY" used to parse PKCS#1-encoded public keys
+    PKCS1PublicKeyPEMType PEMType = "RSA PUBLIC KEY"
+)
+
+func (c *Client) GetPublicKey(keyid string) (crypto.PublicKey, error) {
+    // make JSON for getpubkey
+    payload := orderedmap.New()
+    if keyid != ""{
+        payload.Set("keyid", keyid)
+    } else {
+        return "", fmt.Errorf("Please input keyid.")
+    }
+
+    params := orderedmap.New()
+
+    params.Set("appid", c.appid)
+    params.Set("payload", payload)
+    params.Set("timestamp", strconv.FormatInt(time.Now().UnixNano()/int64(time.Millisecond), 10))
+
+    signString := paramsSortStr(params)
+
+    hmacSha256 := hmac.New(sha256.New, []byte(c.apikey))
+    hmacSha256.Write([]byte(signString))
+    sign := base64.StdEncoding.EncodeToString(hmacSha256.Sum(nil))
+
+    params.Set("sign", sign)
+
+    c.modifyLock.Lock()
+    defer c.modifyLock.Unlock()
+
+    c.action = "GetPublicKey"
+    c.resquest = params
+    
+    // call ehsm kms    
+    resp, err := c.ehsmHttpAction()
+    if err != nil {
+        fmt.Println("ehsmHttpAction error:", err)
+        return "", err
+    }
+
+    defer resp.Body.Close()
+
+    body, err := ioutil.ReadAll(resp.Body)
+    if err != nil {
+        fmt.Println("ReadAll error:", err)
+        return "", err
+    }
+
+    // parse response for cosign
+    var getPublicKeyResponse GetPublicKeyResponse
+
+    str := string(body)
+
+    err = json.Unmarshal([]byte(str), &getPublicKeyResponse)
+    if err != nil{
+        fmt.Println("Unmarshal error:", err)
+        return "", err
+    }
+
+    if getPublicKeyResponse.Code != 200 {
+        return "", fmt.Errorf(getPublicKeyResponse.Message)
+    }
+
+    // parse keyblob to crypto.x509
+    // support EH_RSA_x and EH_EC_P256 
+    pemBytes := []byte(getPublicKeyResponse.Result.Pubkey)
+    derBytes, _ := pem.Decode(pemBytes)
+    if derBytes == nil {
+        return nil, errors.New("PEM decoding failed")
+    }
+    switch derBytes.Type {
+    case string(PublicKeyPEMType):
+        return x509.ParsePKIXPublicKey(derBytes.Bytes)
+    case string(PKCS1PublicKeyPEMType):
+        return x509.ParsePKCS1PublicKey(derBytes.Bytes)
+    default:
+        return nil, fmt.Errorf("unknown Public key PEM file type: %v. Are you passing the correct public key?",
+            derBytes.Type)
+    }
+}

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -1,0 +1,5 @@
+module github.com/intel/ehsm/sdk/go
+
+go 1.20
+
+require github.com/iancoleman/orderedmap v0.2.0

--- a/sdk/go/go.sum
+++ b/sdk/go/go.sum
@@ -1,0 +1,2 @@
+github.com/iancoleman/orderedmap v0.2.0 h1:sq1N/TFpYH++aViPcaKjys3bDClUEU7s5B+z6jq8pNA=
+github.com/iancoleman/orderedmap v0.2.0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=

--- a/sdk/go/sign.go
+++ b/sdk/go/sign.go
@@ -1,0 +1,88 @@
+package ehsm
+
+import (
+    hmac "crypto/hmac"
+    sha256 "crypto/sha256"
+    "encoding/base64"
+    "encoding/json"
+    "fmt"
+    ioutil "io/ioutil"
+    "time"
+    "strconv"
+
+    "github.com/iancoleman/orderedmap"
+)
+
+type SignResponse struct {
+    Code int `json:"code"`
+    Message string `json:"message"`
+    Result struct {
+        Signature string `json:"signature"`
+    } `json:"result"`
+}
+
+func (c *Client) Sign(keyid, digest string) (string, error) {
+    // make JSON for sign
+    payload := orderedmap.New()
+    if keyid != ""{
+        payload.Set("keyid", keyid)
+    } else {
+        return "", fmt.Errorf("Please input keyid.")
+    }
+    if digest != ""{
+        payload.Set("digest", digest)
+    } else {
+        return "", fmt.Errorf("Please input digest.")
+    }
+
+    params := orderedmap.New()
+    params.Set("appid", c.appid)
+    params.Set("payload", payload)
+    params.Set("timestamp", strconv.FormatInt(time.Now().UnixNano()/int64(time.Millisecond), 10))
+
+    signString := paramsSortStr(params)
+
+    hmacSha256 := hmac.New(sha256.New, []byte(c.apikey))
+    hmacSha256.Write([]byte(signString))
+    sign := base64.StdEncoding.EncodeToString(hmacSha256.Sum(nil))
+
+    params.Set("sign", sign)
+
+    c.modifyLock.Lock()
+    defer c.modifyLock.Unlock()
+
+    c.action = "Sign"
+    c.resquest = params
+
+    // call ehsm kms    
+    resp, err := c.ehsmHttpAction()
+    if err != nil {
+        fmt.Println("ehsmHttpAction error:", err)
+        return "", err
+    }
+
+    defer resp.Body.Close()
+
+    body, err := ioutil.ReadAll(resp.Body)
+    if err != nil {
+        fmt.Println("ReadAll error:", err)
+        return "", err
+    }
+    
+    // parse response for cosign
+    var signResponse SignResponse
+
+    str := string(body)
+
+    err = json.Unmarshal([]byte(str), &signResponse)
+    if err != nil{
+        fmt.Println("Unmarshal error:", err)
+        return "", err
+    }
+
+    if signResponse.Code != 200 {
+        return "", fmt.Errorf(signResponse.Message)
+    }
+
+    return signResponse.Result.Signature, nil
+}

--- a/sdk/go/verify.go
+++ b/sdk/go/verify.go
@@ -1,0 +1,92 @@
+package ehsm
+
+import (
+    hmac "crypto/hmac"
+    sha256 "crypto/sha256"
+    "encoding/base64"
+    "encoding/json"
+    "fmt"
+    ioutil "io/ioutil"
+    "time"
+    "strconv"
+
+    "github.com/iancoleman/orderedmap"
+)
+
+type VerifyResponse struct {
+    Code int `json:"code"`
+    Message string `json:"message"`
+    Result struct {
+        Result bool `json:"result"`
+    } `json:"result"`
+}
+
+func (c *Client) Verify(keyid, digest, signature string) (bool, error) {
+    // make JSON for verify
+    payload := orderedmap.New()
+    if keyid != ""{
+        payload.Set("keyid", keyid)
+    } else {
+        return false, fmt.Errorf("Please input keyid.")
+    }
+    if digest != ""{
+        payload.Set("digest", digest)
+    } else {
+        return false, fmt.Errorf("Please input digest.")
+    }
+    if signature != ""{
+        payload.Set("signature", signature)
+    } else {
+        return false, fmt.Errorf("Please input signature.")
+    }
+
+    params := orderedmap.New()
+    params.Set("appid", c.appid)
+    params.Set("payload", payload)
+    params.Set("timestamp", strconv.FormatInt(time.Now().UnixNano()/int64(time.Millisecond), 10))
+
+    signString := paramsSortStr(params)
+
+    hmacSha256 := hmac.New(sha256.New, []byte(c.apikey))
+    hmacSha256.Write([]byte(signString))
+    sign := base64.StdEncoding.EncodeToString(hmacSha256.Sum(nil))
+    params.Set("sign", sign)
+
+    c.modifyLock.Lock()
+    defer c.modifyLock.Unlock()
+
+    c.action = "Verify"
+    c.resquest = params
+    
+    // call ehsm kms
+    resp, err := c.ehsmHttpAction()
+    if err != nil {
+        fmt.Println("ehsmHttpAction error:", err)
+        return false, err
+    }
+
+    defer resp.Body.Close()
+
+    body, err := ioutil.ReadAll(resp.Body)
+    if err != nil {
+        fmt.Println("ReadAll error:", err)
+        return false, err
+    }
+    
+    // parse response for cosign
+    var verifyResponse VerifyResponse
+
+    str := string(body)
+
+    err = json.Unmarshal([]byte(str), &verifyResponse)
+    if err != nil{
+        fmt.Println("Unmarshal error:", err)
+        return false, err
+    }
+
+    if verifyResponse.Code != 200 {
+        return false, fmt.Errorf(verifyResponse.Message)
+    }
+
+    return verifyResponse.Result.Result, nil
+}


### PR DESCRIPTION
currently only support createkey, getpublickey, sign, verify, more interfaces will be added later.

Signed-off-by: wanghaiheng <haihengx.wang@intel.com>