### PR TITLE
check keyusage for symmetric key

### DIFF
--- a/core/Enclave/enclave_hsm.cpp
+++ b/core/Enclave/enclave_hsm.cpp
@@ -438,7 +438,7 @@ sgx_status_t enclave_sign(const ehsm_keyblob_t *cmk, size_t cmk_size,
                           const ehsm_data_t *message, size_t message_size,
                           ehsm_data_t *signature, size_t signature_size)
 {
-    // TODO : make default padding mode for ECC/SM2 
+    // TODO : make default padding mode for ECC/SM2
     sgx_status_t ret = SGX_ERROR_UNEXPECTED;
 
     // check cmk_blob and cmk_blob_size

--- a/core/Enclave/key_factory.cpp
+++ b/core/Enclave/key_factory.cpp
@@ -182,7 +182,7 @@ sgx_status_t ehsm_create_aes_key(ehsm_keyblob_t *cmk)
 {
     sgx_status_t ret = SGX_ERROR_UNEXPECTED;
 
-    if (cmk == NULL)
+    if (cmk == NULL || cmk->metadata.keyusage != EH_KEYUSAGE_ENCRYPT_DECRYPT)
         return ret;
 
     if (cmk->keybloblen == 0)
@@ -635,7 +635,7 @@ sgx_status_t ehsm_create_sm4_key(ehsm_keyblob_t *cmk)
 {
     sgx_status_t ret = SGX_ERROR_UNEXPECTED;
 
-    if (cmk == NULL)
+    if (cmk == NULL || cmk->metadata.keyusage != EH_KEYUSAGE_ENCRYPT_DECRYPT)
         return ret;
 
     if (cmk->keybloblen == 0)


### PR DESCRIPTION
For symmetric key, keyusage must be EH_KEYUSAGE_ENCRYPT_DECRYPT