### PR TITLE
docs: fix typo

### DIFF
--- a/docs/API_Reference.md
+++ b/docs/API_Reference.md
@@ -1080,7 +1080,7 @@ Generate a quote of the eHSM-KMS core enclave for user used to do the SGX DCAP R
       "code": 200,
       "message": "success!",
       "result": {
-         "quote": "Y2hhbGxlbmdl"
+         "challenge": "Y2hhbGxlbmdl"
          "quote": "AwACAAAAAAAHAAwAk5pB***"
       }
     }


### PR DESCRIPTION
Hi, I fix a typo in API_Reference.md, which may cause some confusion.