### PR TITLE
test(sdk/python): add more security server tests

### DIFF
--- a/sdk/python/ehsm/serializers/base.py
+++ b/sdk/python/ehsm/serializers/base.py
@@ -29,17 +29,15 @@ class EHSMBase:
         if "result" not in data:
             raise ValueError("Response does not have attribute 'result'")
         if data["code"] >= 400 and data["code"] < 500:
-            raise InvalidParamException(
-                f"Response has status {data['code']}: {data['message']}"
-            )
+            # `message` may possibly missing in the repsonse data
+            message = f": {data['message']}" if "message" in data else ""
+            raise InvalidParamException(f"Response has status {data['code']}" + message)
         if data["code"] >= 500:
-            raise ServerExceptionException(
-                f"Response has status {data['code']}: {data['message']}"
-            )
+            message = f": {data['message']}" if "message" in data else ""
+            raise InvalidParamException(f"Response has status {data['code']}" + message)
         if data["code"] != 200:
-            raise UnknownException(
-                f"Response has status {data['code']}: {data['message']}"
-            )
+            message = f": {data['message']}" if "message" in data else ""
+            raise InvalidParamException(f"Response has status {data['code']}" + message)
         return cls(
             raw_response=response,
             response=EHSMResponse(code=data["code"], message=data["message"]),

--- a/sdk/python/ehsm/server_tests/test_common.py
+++ b/sdk/python/ehsm/server_tests/test_common.py
@@ -1,0 +1,43 @@
+from functools import partial
+from typing import Dict, Optional
+from pytest import MonkeyPatch
+import pytest
+
+from ehsm.api import Client
+from ehsm.api.enums import KeySpec, KeyUsage, Origin
+from ehsm.exceptions import InvalidParamException
+from ehsm.utils import prepare_params
+from ehsm.session import Session
+from ehsm.server_tests.utils import random_str
+
+
+def test_request_with_invalid_sign(client: Client):
+    post_method = Session.post
+
+    def mock_post(
+        self: Session,
+        url: str,
+        data: Optional[Dict] = None,
+        *,
+        with_signature: bool = False,
+        **kwargs,
+    ):
+        """
+        Replace `sign` field in params with random str if `sign` field exists in params
+        """
+        if with_signature:
+            data = prepare_params(data, client.appid, client.apikey)
+        # set to random value
+        if data is not None and "sign" in data:
+            data["sign"] = random_str(100)
+        return post_method(self, url, data=data, with_signature=with_signature, **kwargs)
+
+    mock = MonkeyPatch()
+    mock.setattr(Session, "post", mock_post)
+    with pytest.raises(InvalidParamException):
+        client.create_key(
+            keyspec=KeySpec.EH_AES_GCM_256,
+            origin=Origin.EH_INTERNAL_KEY,
+            keyusage=KeyUsage.EH_KEYUSAGE_SIGN_VERIFY,
+        )
+    mock.undo()

--- a/sdk/python/ehsm/server_tests/test_key_management.py
+++ b/sdk/python/ehsm/server_tests/test_key_management.py
@@ -1,10 +1,28 @@
 from typing import Tuple, List, Optional
+import pytest
 import random
+import time
 
 from ehsm.api import Client
 from ehsm.api.enums import KeySpec, Origin, KeyUsage
+from ehsm.exceptions import InvalidParamException
 from ehsm.serializers.key_management import ListKeyItem
-from ehsm.server_tests.utils import assert_response_success
+from ehsm.server_tests.utils import assert_response_success, random_str
+
+
+common_keyspec_list = [
+    KeySpec.EH_AES_GCM_128,
+    KeySpec.EH_AES_GCM_192,
+    KeySpec.EH_AES_GCM_256,
+    KeySpec.EH_EC_P224,
+    KeySpec.EH_EC_P256,
+    KeySpec.EH_EC_P256K,
+    KeySpec.EH_EC_P384,
+    KeySpec.EH_EC_P521,
+    KeySpec.EH_RSA_2048,
+    KeySpec.EH_RSA_3072,
+    KeySpec.EH_RSA_4096,
+]
 
 
 def test_get_version(client: Client):
@@ -22,21 +40,7 @@ def create_random_keys(client: Client, k: int = 8):
     # list(Enum) gets all options from Enum
     keys: List[Tuple[KeySpec, Origin, KeyUsage]] = [
         (
-            random.choice(
-                [
-                    KeySpec.EH_AES_GCM_128,
-                    KeySpec.EH_AES_GCM_192,
-                    KeySpec.EH_AES_GCM_256,
-                    KeySpec.EH_EC_P224,
-                    KeySpec.EH_EC_P256,
-                    KeySpec.EH_EC_P256K,
-                    KeySpec.EH_EC_P384,
-                    KeySpec.EH_EC_P521,
-                    KeySpec.EH_RSA_2048,
-                    KeySpec.EH_RSA_3072,
-                    KeySpec.EH_RSA_4096,
-                ]
-            ),
+            random.choice(common_keyspec_list),
             Origin.EH_INTERNAL_KEY,  # external key is not supported yet
             KeyUsage.EH_KEYUSAGE_ENCRYPT_DECRYPT,  # symm. key cannot be used for signing
         )
@@ -83,7 +87,9 @@ def test_enable_disable_key(client: Client):
     assert_response_success(result.response)
     result = client.list_key()
     assert_response_success(result.response)
-    key: Optional[ListKeyItem] = next(filter(lambda k: k.keyid == keyid, result.list), None)
+    key: Optional[ListKeyItem] = next(
+        filter(lambda k: k.keyid == keyid, result.list), None
+    )
     assert key is not None
     assert key.keystate == 0
     # enable it
@@ -91,7 +97,9 @@ def test_enable_disable_key(client: Client):
     assert_response_success(result.response)
     result = client.list_key()
     assert_response_success(result.response)
-    key: Optional[ListKeyItem] = next(filter(lambda k: k.keyid == keyid, result.list), None)
+    key: Optional[ListKeyItem] = next(
+        filter(lambda k: k.keyid == keyid, result.list), None
+    )
     assert key is not None
     assert key.keystate == 1
 
@@ -106,7 +114,9 @@ def test_enable_enable_key(client: Client):
     assert_response_success(result.response)
     result = client.list_key()
     assert_response_success(result.response)
-    key: Optional[ListKeyItem] = next(filter(lambda k: k.keyid == keyid, result.list), None)
+    key: Optional[ListKeyItem] = next(
+        filter(lambda k: k.keyid == keyid, result.list), None
+    )
     assert key is not None
     assert key.keystate == 1
     # enable it again
@@ -114,7 +124,9 @@ def test_enable_enable_key(client: Client):
     assert_response_success(result.response)
     result = client.list_key()
     assert_response_success(result.response)
-    key: Optional[ListKeyItem] = next(filter(lambda k: k.keyid == keyid, result.list), None)
+    key: Optional[ListKeyItem] = next(
+        filter(lambda k: k.keyid == keyid, result.list), None
+    )
     assert key is not None
     assert key.keystate == 1
 
@@ -129,7 +141,9 @@ def test_disable_disable_key(client: Client):
     assert_response_success(result.response)
     result = client.list_key()
     assert_response_success(result.response)
-    key: Optional[ListKeyItem] = next(filter(lambda k: k.keyid == keyid, result.list), None)
+    key: Optional[ListKeyItem] = next(
+        filter(lambda k: k.keyid == keyid, result.list), None
+    )
     assert key is not None
     assert key.keystate == 0
     # enable it again
@@ -137,7 +151,9 @@ def test_disable_disable_key(client: Client):
     assert_response_success(result.response)
     result = client.list_key()
     assert_response_success(result.response)
-    key: Optional[ListKeyItem] = next(filter(lambda k: k.keyid == keyid, result.list), None)
+    key: Optional[ListKeyItem] = next(
+        filter(lambda k: k.keyid == keyid, result.list), None
+    )
     assert key is not None
     assert key.keystate == 0
 
@@ -147,12 +163,112 @@ def test_delete_key(client: Client):
     # before delete: should successfully acquire
     result = client.list_key()
     assert_response_success(result.response)
-    key: Optional[ListKeyItem] = next(filter(lambda k: k.keyid == keyid, result.list), None)
+    key: Optional[ListKeyItem] = next(
+        filter(lambda k: k.keyid == keyid, result.list), None
+    )
     assert key is not None
     # delete: should not be found
     result = client.delete_key(keyid)
     assert_response_success(result.response)
     result = client.list_key()
     assert_response_success(result.response)
-    key: Optional[ListKeyItem] = next(filter(lambda k: k.keyid == keyid, result.list), None)
+    key: Optional[ListKeyItem] = next(
+        filter(lambda k: k.keyid == keyid, result.list), None
+    )
     assert key is None
+
+
+@pytest.mark.parametrize("keyspec", common_keyspec_list)
+def test_create_key_with_invalid_appid(client: Client, keyspec: KeySpec):
+    with pytest.raises(InvalidParamException):
+        client.set_appid(random_str(20))
+        client.create_key(
+            keyspec=keyspec,
+            origin=Origin.EH_INTERNAL_KEY,
+            keyusage=KeyUsage.EH_KEYUSAGE_ENCRYPT_DECRYPT,
+        )
+
+
+@pytest.mark.parametrize("keyspec", common_keyspec_list)
+def test_create_key_with_invalid_apikey(client: Client, keyspec: KeySpec):
+    with pytest.raises(InvalidParamException):
+        client.set_apikey(random_str(100))
+        client.create_key(
+            keyspec=keyspec,
+            origin=Origin.EH_INTERNAL_KEY,
+            keyusage=KeyUsage.EH_KEYUSAGE_ENCRYPT_DECRYPT,
+        )
+
+
+@pytest.mark.parametrize("keyspec", common_keyspec_list)
+def test_create_key_with_future_timestamp(client: Client, keyspec: KeySpec):
+    future_time = time.time() + 1320
+
+    def mock_time(*args, **kwrags):
+        return future_time
+
+    mock = pytest.MonkeyPatch()
+    mock.setattr(time, "time", mock_time)
+    with mock.context() as m:
+        with pytest.raises(InvalidParamException):
+            client.create_key(
+                keyspec=keyspec,
+                origin=Origin.EH_INTERNAL_KEY,
+                keyusage=KeyUsage.EH_KEYUSAGE_ENCRYPT_DECRYPT,
+            )
+    mock.undo()
+
+
+@pytest.mark.parametrize("keyspec", common_keyspec_list)
+def test_create_key_with_past_timestamp(client: Client, keyspec: KeySpec):
+    past_time = time.time() + 1320
+
+    def mock_time(*args, **kwrags):
+        return past_time
+
+    mock = pytest.MonkeyPatch()
+    mock.setattr(time, "time", mock_time)
+    with mock.context() as m:
+        with pytest.raises(InvalidParamException):
+            client.create_key(
+                keyspec=keyspec,
+                origin=Origin.EH_INTERNAL_KEY,
+                keyusage=KeyUsage.EH_KEYUSAGE_ENCRYPT_DECRYPT,
+            )
+    mock.undo()
+
+
+def test_create_key_with_invalid_keyspec(client: Client):
+    keyspec = random_str(12)
+    with pytest.raises(InvalidParamException):
+        client.create_key(
+            keyspec=keyspec,  # type: ignore
+            origin=Origin.EH_INTERNAL_KEY,
+            keyusage=KeyUsage.EH_KEYUSAGE_ENCRYPT_DECRYPT,
+        )
+
+
+@pytest.mark.parametrize("keyspec", common_keyspec_list)
+def test_create_key_with_invalid_origin(client: Client, keyspec: KeySpec):
+    with pytest.raises(InvalidParamException):
+        client.create_key(
+            keyspec=keyspec,
+            origin=random_str(12),  # type: ignore
+            keyusage=KeyUsage.EH_KEYUSAGE_ENCRYPT_DECRYPT,
+        )
+
+
+@pytest.mark.parametrize("keyspec", common_keyspec_list)
+def test_create_key_with_duplicate_request(client: Client, keyspec: KeySpec):
+    result = client.create_key(
+        keyspec=keyspec,
+        origin=Origin.EH_INTERNAL_KEY,
+        keyusage=KeyUsage.EH_KEYUSAGE_ENCRYPT_DECRYPT,
+    )
+    origin_request = result.raw_response.request
+    resp = client._session._client.send(origin_request)
+    # status code is correct with `code` field in response body equals to 400
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "code" in data
+    assert data["code"] == 400


### PR DESCRIPTION
- add test request with invalid appid/apikey/sign
- add test request with invalid params for create_key API
- optimize handling of responses with code `400` and `500` in response body