### PR TITLE
fix: remove invalid branch specification

### DIFF
--- a/docker/Dockerfile.anolisos86
+++ b/docker/Dockerfile.anolisos86
@@ -68,7 +68,7 @@ RUN mkdir jsoncpp \
 
 # Build App from source
 WORKDIR /home
-RUN git clone --recursive -b anolisos https://github.com/intel/ehsm.git \
+RUN git clone --recursive https://github.com/intel/ehsm.git \
     && cd ehsm \
     && make
 


### PR DESCRIPTION
I believe that branch `anolisos` has been merged to `main`. So branch specification here is neither useful nor valid.