### PR TITLE
fix: upgrade 'reqwest' to 0.12.4 to avoid CVE threat

### DIFF
--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1.68"
-reqwest = { version = "0.11.18", features = ["native-tls"] }
+reqwest = { version = "0.12.4", features = ["native-tls"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
There is a [CVE](https://rustsec.org/advisories/RUSTSEC-2024-0336) that affects `reqwest` version 0.11 and lower, so an upgrade is performed.